### PR TITLE
Fix UUID formatting (returned as a string)

### DIFF
--- a/ldap3/protocol/formatters/standard.py
+++ b/ldap3/protocol/formatters/standard.py
@@ -92,7 +92,7 @@ standard_formatter = {
     '1.3.6.1.4.1.1466.115.121.1.56': format_binary,  # LDAP Schema Definition [OBSOLETE]
     '1.3.6.1.4.1.1466.115.121.1.57': format_unicode,  # LDAP Schema Description [OBSOLETE]
     '1.3.6.1.4.1.1466.115.121.1.58': format_unicode,  # Substring assertion
-    '1.3.6.1.1.16.1': format_uuid,  # UUID
+    '1.3.6.1.1.16.1': format_unicode,  # UUID
     '2.16.840.1.113719.1.1.4.1.501': format_uuid,  # GUID (Novell)
     '2.16.840.1.113719.1.1.5.1.0': format_binary,  # Unknown (Novell)
     '2.16.840.1.113719.1.1.5.1.6': format_unicode,  # Case Ignore List (Novell)


### PR DESCRIPTION
Per rfc4530 2.1 UUID (1.3.6.1.1.16.1) syntax is just an ascii string with the UUID's representation instead of its bytes (even though the RFC describes the underlying data format in the first paragraph). Sending this string to UUID(bytes=) results in a ValueException (to recreate, request entryuuid from openldap which uses this syntax).