### PR TITLE
Include `_version.json` file in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include COPYING.txt COPYING.LESSER.txt LICENSE.txt README.rst requirements.txt _version.py
+include COPYING.txt COPYING.LESSER.txt LICENSE.txt README.rst requirements.txt _version.py _version.json


### PR DESCRIPTION
`ldap3-0.9.7.9.tar.gz` on PyPI is missing the `_version.json` file. Hence setup.py fails at https://github.com/cannatag/ldap3/blob/master/setup.py#L31