### PR TITLE
Add raw SASL Credentials field.

### DIFF
--- a/ldap3/operation/bind.py
+++ b/ldap3/operation/bind.py
@@ -117,7 +117,8 @@ def bind_response_to_dict(response):
             'dn': str(response['matchedDN']),
             'message': str(response['diagnosticMessage']),
             'referrals': referrals_to_list(response['referral']),
-            'saslCreds': str(response['serverSaslCreds'])}
+            'saslCreds': str(response['serverSaslCreds']),
+            'raw_saslCreds': bytes(response['serverSaslCreds'])}
 
 
 def sicily_bind_response_to_dict(response):


### PR DESCRIPTION
When using python3, the conversion to str mangles the saslCreds
response.
Add a field to access the raw bytes, this is required for GSSAPI.