### PR TITLE
Use bytes instead of str for SASL Credentials field.

### DIFF
--- a/ldap3/operation/bind.py
+++ b/ldap3/operation/bind.py
@@ -117,7 +117,7 @@ def bind_response_to_dict(response):
             'dn': str(response['matchedDN']),
             'message': str(response['diagnosticMessage']),
             'referrals': referrals_to_list(response['referral']),
-            'saslCreds': str(response['serverSaslCreds'])}
+            'saslCreds': bytes(response['serverSaslCreds']) if response['serverSaslCreds'] is not None else None}
 
 
 def sicily_bind_response_to_dict(response):

--- a/ldap3/protocol/sasl/digestMd5.py
+++ b/ldap3/protocol/sasl/digestMd5.py
@@ -77,7 +77,7 @@ def sasl_digest_md5(connection, controls):
 
     # step One of RFC2831
     result = send_sasl_negotiation(connection, controls, None)
-    if 'saslCreds' in result and result['saslCreds'] != 'None':
+    if 'saslCreds' in result and result['saslCreds'] is not None:
         server_directives = decode_directives(result['saslCreds'])
     else:
         return None
@@ -129,7 +129,7 @@ def decode_directives(directives_string):
     quoting = False
     key = ''
     directives = dict()
-    for c in directives_string:
+    for c in directives_string.decode():
         if state == STATE_KEY and c == '=':
             key = tmp_buffer
             tmp_buffer = ''


### PR DESCRIPTION
When using python3, the conversion to str mangles the saslCreds response thus breaking GSSAPI.
Convert the saslCreds field to bytes, which fixes GSSAPI.