### PR TITLE
Correct dict argument to Connection.modify()

### DIFF
--- a/docs/manual/source/connections.rst
+++ b/docs/manual/source/connections.rst
@@ -92,7 +92,7 @@ With the connection you can perform all the standard LDAP operations:
 
     * dn: distinguish name of the object whose attributes must be modified
 
-    * changes: a dictionary in the form {'attribute1': [(operation, [val1, val2, ...])], 'attribute2': [(operation, [val1, val2, ...])]}, operation is MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, MODIFY_INCREMENT
+    * changes: a dictionary in the form {'attribute1': (operation, [val1, val2, ...]), 'attribute2': (operation, [val1, val2, ...])}, operation is MODIFY_ADD, MODIFY_DELETE, MODIFY_REPLACE, MODIFY_INCREMENT
 
     * controls: additional controls to be used in the request
 


### PR DESCRIPTION
Connection.modify() requires the values of the dict to be Tuple[str, List[str]] not List[Tuple[str, List[str]]].
Otherwise the function raises "ldap3.core.exceptions.LDAPChangesError: malformed change"