### PR TITLE
Avoiding TypeError and Ordered object class

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -676,14 +676,14 @@ class Connection(object):
             if object_class is None:
                 parm_object_class = []
             else:
-                parm_object_class = object_class if isinstance(object_class, SEQUENCE_TYPES) else [object_class]
+                parm_object_class = list(object_class) if isinstance(object_class, SEQUENCE_TYPES) else [object_class]
 
             object_class_attr_name = ''
             if attributes:
                 for attr in attributes:
                     if attr.lower() == 'objectclass':
                         object_class_attr_name = attr
-                        attr_object_class = attributes[object_class_attr_name] if isinstance(attributes[object_class_attr_name], SEQUENCE_TYPES) else [attributes[object_class_attr_name]]
+                        attr_object_class = list(attributes[object_class_attr_name]) if isinstance(attributes[object_class_attr_name], SEQUENCE_TYPES) else [attributes[object_class_attr_name]]
             else:
                 attributes = dict()
 

--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -24,6 +24,7 @@
 # If not, see <http://www.gnu.org/licenses/>.
 
 from os import linesep
+from functools import reduce
 from threading import RLock
 import json
 
@@ -690,7 +691,7 @@ class Connection(object):
             if not object_class_attr_name:
                 object_class_attr_name = 'objectClass'
 
-            attributes[object_class_attr_name] = list(set([object_class for object_class in parm_object_class + attr_object_class]))  # remove duplicate ObjectClasses
+            attributes[object_class_attr_name] = reduce(lambda x, y: x + [y] if y not in x else x, attr_object_class + parm_object_class, [])  # remove duplicate ObjectClasses
 
             if not attributes[object_class_attr_name]:
                 self.last_error = 'objectClass attribute is mandatory'

--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -691,7 +691,7 @@ class Connection(object):
             if not object_class_attr_name:
                 object_class_attr_name = 'objectClass'
 
-            attributes[object_class_attr_name] = reduce(lambda x, y: x + [y] if y not in x else x, attr_object_class + parm_object_class, [])  # remove duplicate ObjectClasses
+            attributes[object_class_attr_name] = reduce(lambda x, y: x + [y] if y not in x else x, parm_object_class + attr_object_class, [])  # remove duplicate ObjectClasses
 
             if not attributes[object_class_attr_name]:
                 self.last_error = 'objectClass attribute is mandatory'


### PR DESCRIPTION
I fixed add method in ldap3.Connection.

parm_object_class and attr_object_class should be same type.
And I propose objectClass attributes remember its order.