### PR TITLE
fixed evaluate_match to handle assertion values containing filter types

### DIFF
--- a/ldap3/operation/search.py
+++ b/ldap3/operation/search.py
@@ -103,29 +103,27 @@ class FilterNode(object):
 
 
 def evaluate_match(match, schema):
-    match = match.strip()
-    if '~=' in match:
+    left_part, equal_sign, right_part = match.strip().partition('=')
+    if not equal_sign:
+        raise LDAPInvalidFilterError('invalid matching assertion')
+    if left_part.endswith('~'):
         tag = MATCH_APPROX
-        left_part, _, right_part = match.partition('~=')
-        left_part = left_part.strip()
+        left_part = left_part[:-1].strip()
         right_part = right_part.strip()
         assertion = {'attr': left_part, 'value': validate_assertion_value(schema, left_part, right_part)}
-    elif '>=' in match:
+    elif left_part.endswith('>'):
         tag = MATCH_GREATER_OR_EQUAL
-        left_part, _, right_part = match.partition('>=')
-        left_part = left_part.strip()
+        left_part = left_part[:-1].strip()
         right_part = right_part.strip()
         assertion = {'attr': left_part, 'value': validate_assertion_value(schema, left_part, right_part)}
-    elif '<=' in match:
+    elif left_part.endswith('<'):
         tag = MATCH_LESS_OR_EQUAL
-        left_part, _, right_part = match.partition('<=')
-        left_part = left_part.strip()
+        left_part = left_part[:-1].strip()
         right_part = right_part.strip()
         assertion = {'attr': left_part, 'value': validate_assertion_value(schema, left_part, right_part)}
-    elif ':=' in match:
+    elif left_part.endswith(':'):
         tag = MATCH_EXTENSIBLE
-        left_part, _, right_part = match.partition(':=')
-        left_part = left_part.strip()
+        left_part = left_part[:-1].strip()
         right_part = right_part.strip()
         extended_filter_list = left_part.split(':')
         matching_rule = None
@@ -160,12 +158,12 @@ def evaluate_match(match, schema):
         attribute_name = attribute_name.strip() if attribute_name else None
         matching_rule = matching_rule.strip() if matching_rule else None
         assertion = {'attr': attribute_name, 'value': validate_assertion_value(schema, attribute_name, right_part), 'matchingRule': matching_rule, 'dnAttributes': dn_attributes}
-    elif match.endswith('=*'):
+    elif right_part == '*':
         tag = MATCH_PRESENT
-        assertion = {'attr': match[:-2]}
-    elif '=' in match and '*' in match:
+        left_part = left_part.strip()
+        assertion = {'attr': left_part}
+    elif '*' in right_part:
         tag = MATCH_SUBSTRING
-        left_part, _, right_part = match.partition('=')
         left_part = left_part.strip()
         right_part = right_part.strip()
         substrings = right_part.split('*')
@@ -173,14 +171,11 @@ def evaluate_match(match, schema):
         final = validate_assertion_value(schema, left_part, substrings[-1]) if substrings[-1] else None
         any_string = [validate_assertion_value(schema, left_part, substring) for substring in substrings[1:-1] if substring]
         assertion = {'attr': left_part, 'initial': initial, 'any': any_string, 'final': final}
-    elif '=' in match:
+    else:
         tag = MATCH_EQUAL
-        left_part, _, right_part = match.partition('=')
         left_part = left_part.strip()
         right_part = right_part.strip()
         assertion = {'attr': left_part, 'value': validate_assertion_value(schema, left_part, right_part)}
-    else:
-        raise LDAPInvalidFilterError('invalid matching assertion')
 
     return FilterNode(tag, assertion)
 


### PR DESCRIPTION
According to RFC4515 section 3, an LDAP search filter

    (cn=a<=b=>c)

represents an equal match having an attribute "cn" and an assertion value "a<=b=>c" instead of representing a less or equal match having an attribute "cn=a" and and assertion value "b=>c".

This patch fixes ldap3.operation.search.evaluate_match to handle that and similar cases correctly.