### PR TITLE
Support round-robin DNS with GSSAPI auth

### DIFF
--- a/ldap3/protocol/sasl/kerberos.py
+++ b/ldap3/protocol/sasl/kerberos.py
@@ -26,6 +26,8 @@
 # original code by Hugh Cole-Baker, modified by Peter Foley
 # it needs the gssapi package
 
+import socket
+
 from ...core.exceptions import LDAPPackageUnavailableError, LDAPCommunicationError
 
 try:
@@ -47,7 +49,8 @@ def sasl_gssapi(connection, controls):
     from RFC 4752. Does not support any security layers, only authentication!
     """
 
-    target_name = gssapi.Name('ldap@' + connection.server.host, gssapi.NameType.hostbased_service)
+    hostname = socket.gethostbyaddr(connection.socket.getpeername()[0])[0]
+    target_name = gssapi.Name('ldap@' + hostname, gssapi.NameType.hostbased_service)
     ctx = gssapi.SecurityContext(name=target_name, mech=gssapi.MechType.kerberos)
     in_token = None
     try:


### PR DESCRIPTION
Our university has multiple LDAP servers presented in a round-robin when one resolves the domain name for our LDAP service. Each of those servers has its own service principle, something like `ldap-<n>.oak.ox.ac.uk`.

Previously, the GSSAPI negotiation expected to authenticate against the round-robin DNS name, not the hostname of the server it connected to. This pull request performs an rDNS on the server we're connected to and then attempts to negotiate with that name.