### PR TITLE
Allow choosing credentials with GSSAPI

### DIFF
--- a/ldap3/protocol/sasl/kerberos.py
+++ b/ldap3/protocol/sasl/kerberos.py
@@ -48,7 +48,9 @@ def sasl_gssapi(connection, controls):
     """
 
     target_name = gssapi.Name('ldap@' + connection.server.host, gssapi.NameType.hostbased_service)
-    ctx = gssapi.SecurityContext(name=target_name, mech=gssapi.MechType.kerberos)
+    creds = gssapi.Credentials(name=gssapi.Name(connection.user), usage='initiate') if connection.user else None
+    ctx = gssapi.SecurityContext(name=target_name, mech=gssapi.MechType.kerberos,
+                                 creds=creds)
     in_token = None
     try:
         while True:


### PR DESCRIPTION
If an application is using a credential cache collection with multiple credentials, it would be handy to have a way to specify which credentials to use in the GSSAPI negotiation.

This reuses `connection.user` to find the desired credentials.