### PR TITLE
Docs improvements for GSSAPI auth

### DIFF
--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -168,7 +168,7 @@ you pass None as 'realm' the default realm of the LDAP server will be used.
 Kerberos
 ^^^^^^^^
 
-Kerberos authentication uses the python-gssapi package. You must install it and configure your Kerberos environment to use the GSSAPI mechanism::
+Kerberos authentication uses the ``gssapi`` package. You must install it and configure your Kerberos environment to use the GSSAPI mechanism::
 
     import ldap3
     import ssl

--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -188,16 +188,16 @@ You can specify which Kerberos client principal should be used with the ``user``
         server, user='ldap-client/client.example.com',
         authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
 
-By default the library attempts to bind against the service principal for the domain you attempted to connect to. If your target LDAP service uses a round-robin DNS, it's likely that the hostname you connect to won't match. In this case, you can either specify a hostname explicitly as the first element of the ``sasl_credential`` connection parameter, or pass ``True`` as the first element to do a reverse DNS lookup::
+By default the library attempts to bind against the service principal for the domain you attempted to connect to. If your target LDAP service uses a round-robin DNS, it's likely that the hostname you connect to won't match. In this case, you can either specify a hostname explicitly as the first element of the ``sasl_credentials`` connection parameter, or pass ``True`` as the first element to do a reverse DNS lookup::
 
     # Override server hostname for authentication
     connection = ldap3.Connection(
-        server, sasl_credential=('ldap-3.example.com',),
+        server, sasl_credentials=('ldap-3.example.com',),
         authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
 
     # Perform a reverse DNS lookup to determine the hostname to authenticate against.
     connection = ldap3.Connection(
-        server, sasl_credential=(True,),
+        server, sasl_credentials=(True,),
         authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
 
 

--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -180,6 +180,24 @@ Kerberos authentication uses the ``gssapi`` package. You must install it and con
     connection.bind()
     print(connection.extend.standard.who_am_i())
 
+You can specify which Kerberos client principal should be used with the ``user`` parameter when declaring the ``Connection``::
+
+    connection = ldap3.Connection(
+        server, user='ldap-client/client.example.com',
+        authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
+
+By default the library attempts to bind against the service principal for the domain you attempted to connect to. If your target LDAP service uses a round-robin DNS, it's likely that the hostname you connect to won't match. In this case, you can either specify a hostname explicitly as the first element of the ``sasl_credential`` connection parameter, or pass ``True`` as the first element to do a reverse DNS lookup::
+
+    # Override server hostname for authentication
+    connection = ldap3.Connection(
+        server, sasl_credential=('ldap-3.example.com',),
+        authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
+
+    # Perform a reverse DNS lookup to determine the hostname to authenticate against.
+    connection = ldap3.Connection(
+        server, sasl_credential=(True,),
+        authentication=ldap3.SASL, sasl_mechanism='GSSAPI')
+
 
 
 NTLM

--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -165,6 +165,8 @@ you pass None as 'realm' the default realm of the LDAP server will be used.
 **Again, remember that DIGEST-MD5 is deprecated and should not be used.**
 
 
+.. _sasl-kerberos:
+
 Kerberos
 ^^^^^^^^
 

--- a/docs/manual/source/ldap3.protocol.sasl.kerberos.rst
+++ b/docs/manual/source/ldap3.protocol.sasl.kerberos.rst
@@ -1,6 +1,8 @@
 ldap3.protocol.sasl.kerberos module
 ===================================
 
+See :ref:`the Kerberos BIND documentation <sasl-kerberos>` for usage information.
+
 .. automodule:: ldap3.protocol.sasl.kerberos
     :members:
     :undoc-members:

--- a/docs/manual/source/quicktour.rst
+++ b/docs/manual/source/quicktour.rst
@@ -110,6 +110,10 @@ when you leave the context. The Unbind operation will be tried even if the opera
 Binding
 -------
 
+.. note::
+
+   For more comprehensive information about binding, see the :doc:`BIND <bind>` documentation.
+
 You can bind (authenticate) to the server with any of the authentication methods defined in the LDAP v3 protocol:
 Anonymous, Simple and SASL. An additional NTML method is defined to access Microsoft Active Directory servers.
 

--- a/docs/manual/source/quicktour.rst
+++ b/docs/manual/source/quicktour.rst
@@ -127,6 +127,10 @@ succesful the library will raise an LDAPBindError exception.
 Searching
 ---------
 
+.. note::
+
+   For more comprehensive information about searching, see the :doc:`SEARCH <searches>` documentation.
+
 Search operation is enhanced with a few parameters:
 
 * get_operational_attributes: when True retrieves the operational (system generated) attributes for each of the result


### PR DESCRIPTION
Here is some documentation for the changes made in 3fa34ce, as offered in #89.

I've also added some links to the bind and search documentation from other bits of the docs (quicktour and autogen'd docs for `ldap3.protocol.sasl.kerberos`).