### PR TITLE
Added response_to_dict_list() method to the Connection object.

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -1096,6 +1096,26 @@ class Connection(object):
 
             return None
 
+    def response_to_dict_list(self,
+                         raw=False,
+                         search_result=None):
+        with self.lock:
+            if search_result is None:
+                search_result = self.response
+
+            if isinstance(search_result, SEQUENCE_TYPES):
+                dict_list = list()
+
+                for response in search_result:
+                    if response['type'] == 'searchResEntry':
+                        if raw:
+                            entry = dict(response['raw_attributes'])
+                        else:
+                            entry = dict(response['attributes'])
+                        dict_list.append(entry)
+
+                return dict_list
+
     def response_to_json(self,
                          raw=False,
                          search_result=None,


### PR DESCRIPTION
When returning entries, the resultant collection can require additional processing on the client or server side to extract the attribute representation of each entry. This produces a list of entries in plain dict() format such that each entry is simply {attribute: value,...}.