### PR TITLE
Fix usage of 'in' with entry object

### DIFF
--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -72,7 +72,11 @@ class Entry(object):
         raise StopIteration
 
     def __contains__(self, item):
-        return True if self.__getitem__(item) else False
+        try:
+            if self.__getitem__(item):
+                return True
+        except LDAPKeyError:
+            return False
 
     def __getattr__(self, item):
         if isinstance(item, STRING_TYPES):


### PR DESCRIPTION
When you use 'in' statement on entry object, it throw an exception when attribute is not in entry but where attribute is present, it simply return True.

So I try to fix this issue by "try/catch"ing call to __getitem__() method