### PR TITLE
Make contains work with false values

### DIFF
--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -73,7 +73,8 @@ class Entry(object):
 
     def __contains__(self, item):
         try:
-            return True if self.__getitem__(item) else False
+            self.__getitem__(item)
+            return True
         except LDAPKeyError:
             return False
 


### PR DESCRIPTION
I think contains will reply false if it contains a false value. But It should return true. This last commit fix this issue.