### PR TITLE
Added LM:NTLM hash auth support to NTLM bind

### DIFF
--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -220,6 +220,9 @@ The ldap3 library supports an additional method to bind to Active Directory serv
 This authentication method is specific for Active Directory and uses a proprietary authentication protocol named SICILY
 that breaks the LDAP RFC but can be used to access AD.
 
+When binding via NTLM, it is also possible to authenticate with an LM:NTLM hash rather than a password::
+
+    c = Connection(s, user="AUTHTEST\\Administrator", password="E52CAC67419A9A224A3B108F3FA6CB6D:8846F7EAEE8FB117AD06BDD830B7586C", authentication=NTLM)
 
 LDAPI (LDAP over IPC)
 ---------------------

--- a/ldap3/utils/ntlm.py
+++ b/ldap3/utils/ntlm.py
@@ -31,6 +31,7 @@ from socket import gethostname
 from time import time
 import hmac
 import hashlib
+import binascii
 from os import urandom
 
 try:
@@ -488,5 +489,10 @@ class NtlmClient(object):
         return nt_challenge_response
 
     def ntowf_v2(self):
-        password_digest = hashlib.new('MD4', self._password.encode('utf-16-le')).digest()
+        passparts = self._password.split(':')
+        if len(passparts) == 2 and len(passparts[0]) == 32 and len(passparts[1]) == 32:
+            #The specified password is an LM:NTLM hash
+            password_digest = binascii.unhexlify(passparts[1])
+        else:
+            password_digest = hashlib.new('MD4', self._password.encode('utf-16-le')).digest()
         return hmac.new(password_digest, (self.user_name.upper() + self.user_domain).encode('utf-16-le')).digest()


### PR DESCRIPTION
I'm not sure if you are interested in a feature like this, but as a pentester it is often useful to authenticate to the server with a NTLM hash rather than a password.
I've added the option to specify this as a LM:NTLM hash (similar to how metasploit does it), which works when done as in the added documentation option (that are the hashes for "password").

I haven't tested building the docs, so I hope my formatting is correct there.