### PR TITLE
fix dead link github.com/cannatag/ldap3/dev

### DIFF
--- a/docs/manual/source/welcome.rst
+++ b/docs/manual/source/welcome.rst
@@ -79,7 +79,7 @@ You can download the latest released source code at https://github.com/cannatag/
 Contribuiting to this project
 -----------------------------
 
-ldap3 source is hosted on github. You can contribute to the ldap3 project on https://github.com/cannatag/ldap3/dev
+ldap3 source is hosted on github. You can contribute to the ldap3 project on https://github.com/cannatag/ldap3
 forking the project and submitting a *pull request+ with your modifications.
 
 


### PR DESCRIPTION
https://github.com/cannatag/ldap3/dev is 404 now.