### PR TITLE
Update docs: use_tls --> use_ssl

### DIFF
--- a/docs/manual/source/servers.rst
+++ b/docs/manual/source/servers.rst
@@ -6,7 +6,7 @@ Server object
 -------------
 The Server object specifies the DSA (Directory Server Agent) LDAP server that will be used by the connection. To create a new Server object the following parameters are available:
 
-* host: name or ip or the complete url in the scheme://hostname:hostport format of the server (required) - port and scheme (ldap or ldaps) defined here have precedence over the parameters port and use_tls
+* host: name or ip or the complete url in the scheme://hostname:hostport format of the server (required) - port and scheme (ldap or ldaps) defined here have precedence over the parameters port and use_ssl
 
 * port: the port where the DSA server is listening (defaults to 389, for a cleartext connection, 636 for a secured connection)
 

--- a/docs/manual/source/ssltls.rst
+++ b/docs/manual/source/ssltls.rst
@@ -34,7 +34,7 @@ Tls object uses the ssl module of the Python standard library with additional ch
 
 The needed constants are defined in the ssl package.
 
-IF you don't use a specific Tls object and set use_tls=True in the Server definition, a default Tls object will be used, it has no certificate
+IF you don't use a specific Tls object and set use_ssl=True in the Server definition, a default Tls object will be used, it has no certificate
 files, uses the ssl.PROTOCOL_SSLv23 (if available in your Python interpreter) and performs no validation of the server certificate.
 It's recommended to set validate=ssl.CERT_REQUIRED to verify the certificate server. Example::
 


### PR DESCRIPTION
Noticed a small typo when reading through the docs. There is no `use_tls` parameter for a `Server` object, it's `use_ssl`.