### PR TITLE
Escape all octets greater than 0x7F that are not part of a valid UTF-8.

### DIFF
--- a/ldap3/utils/conv.py
+++ b/ldap3/utils/conv.py
@@ -57,6 +57,8 @@ def escape_filter_chars(text):
     output = output.replace(r'(', r'\28')
     output = output.replace(r')', r'\29')
     output = output.replace('\x00', r'\00')
+    # escape all octets greater than 0x7F that are not part of a valid UTF-8
+    output = ''.join(c if c <= '\x7f' else r'\x%x' % ord(c) for c in output)
     return output
 
 


### PR DESCRIPTION
In respect of RFC 4515 these characters must be escaped too.