### PR TITLE
Only use default certs if no custom CA info given

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -170,7 +170,7 @@ class Tls(object):
                 ssl_context = ssl.SSLContext(self.version)
                 if self.ca_certs_file or self.ca_certs_path or self.ca_certs_data:
                     ssl_context.load_verify_locations(self.ca_certs_file, self.ca_certs_path, self.ca_certs_data)
-                if self.validate != ssl.CERT_NONE:
+                elif self.validate != ssl.CERT_NONE:
                     ssl_context.load_default_certs(Purpose.SERVER_AUTH)
 
             if self.private_key_file:


### PR DESCRIPTION
Only use default certs if no custom CA info given.  This matches the behavior of `ssl.create_default_context` [from the builtin ssl module](https://github.com/python/cpython/blob/78644cf0f4b475328c3b59e4d73c84df8a2ab7aa/Lib/ssl.py#L471).