### PR TITLE
TLS: support client cert and key file provided in the same file

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -173,7 +173,7 @@ class Tls(object):
                 elif self.validate != ssl.CERT_NONE:
                     ssl_context.load_default_certs(Purpose.SERVER_AUTH)
 
-            if self.private_key_file:
+            if self.certificate_file:
                 ssl_context.load_cert_chain(self.certificate_file, keyfile=self.private_key_file, password=self.private_key_password)
             ssl_context.check_hostname = False
             ssl_context.verify_mode = self.validate


### PR DESCRIPTION
Addresses issue #203.

Make `self.certificate_file` be the primary criterion for invoking `load_cert_chain()` instead of `self.private_key_file`.

The `certfile` argument to `ssl_context.load_cert_chain()` is allowed to contain both, private key and certificate. In that case, no private key file needs to be provided. Support that case.

I have successfully tested this patch against an LDAP server that requires a client certificate to be presented. Tested with a `Tls` object defining only `local_certificate_file`, but leaving  `local_private_key_file` set to `None`. `local_certificate_file` pointed to a file containing key and cert. Bind and other operations succeeded, log inspection showed that the client (ldap3) properly presented the cert (expected, as of the corresponding Python docs).

