### PR TITLE
added support for finding object by GUID on AD in safe_dn()

### DIFF
--- a/ldap3/utils/dn.py
+++ b/ldap3/utils/dn.py
@@ -317,7 +317,11 @@ def safe_dn(dn, decompose=False, reverse=False):
     else:
         escaped_dn = ''
 
-    if '@' not in dn and '\\' not in dn:  # active directory UPN (User Principal Name) consist of an account, the at sign (@) and a domain, or the domain level logn name domain\username
+    # Active Directory allows looking up objects by putting its GUID in a specially-formatted DN
+    # (e.g. '<GUID=7b95f0d5-a3ed-486c-919c-077b8c9731f2>')
+    if dn.startswith('<GUID=') and dn.endswith('>'):
+        escaped_dn = dn
+    elif '@' not in dn and '\\' not in dn:  # active directory UPN (User Principal Name) consist of an account, the at sign (@) and a domain, or the domain level logn name domain\username
         for component in parse_dn(dn, escape=True):
             if decompose:
                 escaped_dn.append((component[0], component[1], component[2]))


### PR DESCRIPTION
MS Active Directory lets you use DN syntaxes like '<GUID=7b95f0d5-a3ed-486c-919c-077b8c9731f2>' to look up objects by GUID.

This PR modifies DN sanitization code in safe_dn() to support this DN syntax.