### PR TITLE
MockSyncStrategy: Implement request decoding

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -617,3 +617,32 @@ class MockBaseStrategy(object):
             pass
 
         return False
+
+    @staticmethod
+    def decode_request(message_type, component):
+        if message_type == 'bindRequest':
+            result = bind_request_to_dict(component)
+        elif message_type == 'unbindRequest':
+            result = dict()
+        elif message_type == 'addRequest':
+            result = add_request_to_dict(component)
+        elif message_type == 'compareRequest':
+            result = compare_request_to_dict(component)
+        elif message_type == 'delRequest':
+            result = delete_request_to_dict(component)
+        elif message_type == 'extendedReq':
+            result = extended_request_to_dict(component)
+        elif message_type == 'modifyRequest':
+            result = modify_request_to_dict(component)
+        elif message_type == 'modDNRequest':
+            result = modify_dn_request_to_dict(component)
+        elif message_type == 'searchRequest':
+            result = search_request_to_dict(component)
+        elif message_type == 'abandonRequest':
+            result = abandon_request_to_dict(component)
+        else:
+            if log_enabled(ERROR):
+                log(ERROR, 'unknown request <%s>', message_type)
+            raise LDAPUnknownRequestError('unknown request')
+        result['type'] = message_type
+        return result

--- a/ldap3/strategy/mockSync.py
+++ b/ldap3/strategy/mockSync.py
@@ -100,7 +100,7 @@ class MockSyncStrategy(MockBaseStrategy, SyncStrategy):  # class inheritance seq
         MockBaseStrategy.__init__(self)
 
     def send(self, message_type, request, controls=None):
-        self.connection.request = None
+        self.connection.request = MockBaseStrategy.decode_request(message_type, request)
         if self.connection.listening:
             return message_type, request, controls
         else:


### PR DESCRIPTION
**Alternative to #282: Please only merge one of these PRs**

Until now, `MockSyncStrategy` did not save requests in the `connection`
object. This breaks the automatic Reader generation in
`connection._get_entries`, rendering connection.entries unusable.

This patch implements a `decode_request` staticmethod for the
MockBaseStrategy analogous to the `BaseStrategy`, from where the code
is mostly copied over. I'd put it up to discussion if this code duplication is
the right way to go, or whether the `BaseStrategy.decode_request` should
have the `message_type` and `component` extraction removed, so that it
can also be used by `Mock{Base,Sync}Strategy`.