### PR TITLE
MockSyncStrategy: Implement request decoding (alternative)

### DIFF
--- a/ldap3/strategy/base.py
+++ b/ldap3/strategy/base.py
@@ -294,7 +294,7 @@ class BaseStrategy(object):
             message_controls = build_controls_list(controls)
             if message_controls is not None:
                 ldap_message['controls'] = message_controls
-            self.connection.request = BaseStrategy.decode_request(ldap_message)
+            self.connection.request = BaseStrategy.decode_request(message_type, request)
             self.connection.request['controls'] = controls
             self._outstanding[message_id] = self.connection.request
             self.sending(ldap_message)
@@ -581,9 +581,7 @@ class BaseStrategy(object):
         return control_type, {'description': Oids.get(control_type, ''), 'criticality': criticality, 'value': control_value}
 
     @staticmethod
-    def decode_request(ldap_message):
-        message_type = ldap_message.getComponentByName('protocolOp').getName()
-        component = ldap_message['protocolOp'].getComponent()
+    def decode_request(message_type, component):
         if message_type == 'bindRequest':
             result = bind_request_to_dict(component)
         elif message_type == 'unbindRequest':

--- a/ldap3/strategy/ldifProducer.py
+++ b/ldap3/strategy/ldifProducer.py
@@ -99,7 +99,7 @@ class LdifProducerStrategy(BaseStrategy):
         if message_controls is not None:
             ldap_message['controls'] = message_controls
 
-        self.connection.request = BaseStrategy.decode_request(ldap_message)
+        self.connection.request = BaseStrategy.decode_request(message_type, request)
         self.connection.request['controls'] = controls
         self._outstanding[message_id] = self.connection.request
         return message_id

--- a/ldap3/strategy/mockSync.py
+++ b/ldap3/strategy/mockSync.py
@@ -25,6 +25,7 @@
 
 from ..core.results import DO_NOT_RAISE_EXCEPTIONS
 from .mockBase import MockBaseStrategy
+from .base import BaseStrategy
 from .sync import SyncStrategy
 from ..operation.bind import bind_response_to_dict
 from ..operation.delete import delete_response_to_dict
@@ -100,7 +101,7 @@ class MockSyncStrategy(MockBaseStrategy, SyncStrategy):  # class inheritance seq
         MockBaseStrategy.__init__(self)
 
     def send(self, message_type, request, controls=None):
-        self.connection.request = None
+        self.connection.request = BaseStrategy.decode_request(message_type, request)
         if self.connection.listening:
             return message_type, request, controls
         else:


### PR DESCRIPTION
**Alternative to #281: Please only merge one of these PRs**

Until now, MockSyncStrategy did not save requests in the connection
object. This breaks the automatic Reader generation in
connection._get_entries, rendering connection.entries unusable.

This patch removes some seemingly redundant logic that separating the
message type and request from the ldap message in the
BaseStrategy.decode_request staticmethod. Both of these values are
already known by the callers, allowing it to be used in the
MockSyncStrategy.