### PR TITLE
Fix ObjectDef remove_attribute

### DIFF
--- a/ldap3/abstract/objectDef.py
+++ b/ldap3/abstract/objectDef.py
@@ -195,17 +195,17 @@ class ObjectDef(object):
         if isinstance(item, STRING_TYPES):
             key = ''.join(item.split()).lower()
         elif isinstance(item, AttrDef):
-            key = item.key
+            key = item.key.lower()
 
         if key:
             for attr in self._attributes:
-                if item == attr.lower():
+                if key == attr.lower():
                     del self._attributes[attr]
                     break
             else:
                 raise LDAPKeyError('key \'%s\' not present' % key)
         else:
-            raise LDAPAttributeError('key must be str or AttrDef not ' + str(type(key)))
+            raise LDAPAttributeError('key must be str or AttrDef not ' + str(type(item)))
 
     def clear_attributes(self):
         """Empty the ObjectDef attribute list


### PR DESCRIPTION
Properly handle when item is `AttrDef`:
`item == attr.lower()` is an `AttrDef` to `basestring` comparison, which will
always return `False` because of the implementation of `__eq__` on `AttrDef`.
Replace with `key == attr.lower()`

This did not happen in the following because the implementation of `__isub__` does an `isinstance` check and passes `other.key` in the case where `other` is `AttrDef`
```
o = ObjectDef(...)
o -= 'foo'
```

`LDAPAttributeError` was was returning type of key instead of item (key
would always be `NoneType` in the situation that item was not string or
`AttrDef`)


I would have added a test for this, but I don't see a test case that tests `ObjectDef` directly.