### PR TITLE
Prevent NoneTypes in cursor entries

### DIFF
--- a/ldap3/abstract/cursor.py
+++ b/ldap3/abstract/cursor.py
@@ -253,7 +253,8 @@ class Cursor(object):
         self.entries = []
         for r in response:
             entry = self._create_entry(r)
-            self.entries.append(entry)
+            if entry is not None:
+                self.entries.append(entry)
 
         self.execution_time = datetime.now()
 


### PR DESCRIPTION
I don't know if this is intended behavior or not, but the following happens
```python
connection.search('dc=foo,dc=bar', '(objectClass=Computer)')
print len(connection.entries) # => 1
print connection.entries # => [<legitimate entry>]

object_def = ObjectDef('Computer', connection)
reader = Reader(connection, object_def, 'dc=foo,dc=bar')
reader.search()
print len(reader.entries) # => 4
print reader.entries # => [<legitimate entry>, None, None, None]
```

It looks like the code that ignores `searchResRef` is different between `connection.search` and `reader.search()`.

This is an attempt to fix it so None is not appended to entries. However, I don't know if this was by design.