### PR TITLE
use SHA1 algorithm name for HASHED_SHA to follow newer OpenSSL

### DIFF
--- a/ldap3/utils/hashed.py
+++ b/ldap3/utils/hashed.py
@@ -36,7 +36,7 @@ from ..core.exceptions import LDAPInvalidHashAlgorithmError
 
 algorithms_table = {
     HASHED_MD5: ('md5', 'MD5'),
-    HASHED_SHA: ('sha', 'DSA-SHA'),
+    HASHED_SHA: ('sha', 'SHA1'),
     HASHED_SHA256: ('sha256', 'SHA256'),
     HASHED_SHA384: ('sha384', 'SHA384'),
     HASHED_SHA512: ('sha512', 'SHA512')


### PR DESCRIPTION
`ldap3.utils.hashed.hashed(ldap3.utils.hashed.HASHED_SHA, password)` fails with newer OpenSSL as the below, thus use `SHA1` instead of obsolete `DSA-SHA`:

```console
$ python3 -c 'import ldap3;print(ldap3.utils.hashed.hashed(ldap3.utils.hashed.HASHED_SHA,"p"))'
Traceback (most recent call last):
  File "/usr/lib/python3.5/hashlib.py", line 122, in __hash_new
    return _hashlib.new(name, data)
ValueError: unsupported hash type

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/ldap3/utils/hashed.py", line 66, in hashed
    digest = hashlib.new(algorithms_table[algorithm][1], value).digest()
  File "/usr/lib/python3.5/hashlib.py", line 128, in __hash_new
    return __get_builtin_constructor(name)(data)
  File "/usr/lib/python3.5/hashlib.py", line 95, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type DSA-SHA

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/ldap3/utils/hashed.py", line 68, in hashed
    raise LDAPInvalidHashAlgorithmError('Hash algorithm ' + str(algorithm) + ' not available')
ldap3.core.exceptions.LDAPInvalidHashAlgorithmError: Hash algorithm SHA not available
```