### PR TITLE
Make ObjectDef use aliased attribute names, too

### DIFF
--- a/ldap3/abstract/objectDef.py
+++ b/ldap3/abstract/objectDef.py
@@ -112,15 +112,13 @@ class ObjectDef(object):
     def __getattr__(self, item):
         item = ''.join(item.split()).lower()
         if '_attributes' in self.__dict__:
-            for attr in self.__dict__['_attributes']:
-                if item == attr.lower():
-                    break
-            else:
+            try:
+                return self._attributes[attr]
+            except KeyError:
                 raise LDAPKeyError('key \'%s\' not present' % item)
 
-            return self._attributes[attr]
-
-        raise LDAPKeyError('internal _attributes property not defined')
+        else:
+            raise LDAPKeyError('internal _attributes property not defined')
 
     def __setattr__(self, key, value):
         raise LDAPObjectError('object \'%s\' is read only' % key)


### PR DESCRIPTION
ObjectDef now uses ciDict, but accessing members was still implemented by iterating and comparing lowercase key. This patch makes use of ciDict built-in features.

Example: 
`person['SURNAME'] == person['sn']`