### PR TITLE
Explicitly convert int to str in queries

### DIFF
--- a/ldap3/abstract/cursor.py
+++ b/ldap3/abstract/cursor.py
@@ -466,9 +466,9 @@ class Reader(Cursor):
                         elif validated is not True:  # a valid LDAP value equivalent to the actual values
                                 value = validated
                     if val_not:
-                        query += '!' + val_search_operator + value
+                        query += '!' + val_search_operator + str(value)
                     else:
-                        query += val_search_operator + value
+                        query += val_search_operator + str(value)
 
                     query += ';'
                 query = query[:-1] + ', '


### PR DESCRIPTION
Python 2 & 3 raise an error when it tries to implicitly convert int to str for the "+" operation. Since we're building a string query anyway, convert ints to strings explicitly.