### PR TITLE
Fixed logic where checks would be made against schema.attribute_types…

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -743,8 +743,9 @@ class Connection(object):
                         attribute_name_to_check = attribute_name.split(';')[0]
                     else:
                         attribute_name_to_check = attribute_name
-                    if attribute_name_to_check not in get_config_parameter('ATTRIBUTES_EXCLUDED_FROM_CHECK') and attribute_name_to_check not in self.server.schema.attribute_types:
-                        raise LDAPAttributeError('invalid attribute type ' + attribute_name_to_check)
+                    if self.server.schema.attribute_types is not None:
+                        if attribute_name_to_check not in get_config_parameter('ATTRIBUTES_EXCLUDED_FROM_CHECK') and attribute_name_to_check not in self.server.schema.attribute_types:
+                            raise LDAPAttributeError('invalid attribute type ' + attribute_name_to_check)
 
             request = search_operation(search_base,
                                        search_filter,

--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -134,14 +134,19 @@ def validate_attribute_value(schema, name, value, auto_encode):
     if schema:
         if ';' in name:
             name = name.split(';')[0]
-        if schema.attribute_types is not None and name not in schema.attribute_types and name not in get_config_parameter('ATTRIBUTES_EXCLUDED_FROM_CHECK'):
-            raise LDAPAttributeError('invalid attribute ' + name)
+
         if schema.object_classes is not None and name == 'objectClass':
             if value not in get_config_parameter('CLASSES_EXCLUDED_FROM_CHECK') and value not in schema.object_classes:
                 raise LDAPObjectClassError('invalid class in objectClass attribute: ' + value)
-        # encodes to utf-8 for well known Unicode LDAP syntaxes
-        if auto_encode and (schema.attribute_types[name].syntax in get_config_parameter('UTF8_ENCODED_SYNTAXES') or name in get_config_parameter('UTF8_ENCODED_TYPES')):
-            value = to_unicode(value)  # tries to convert from local encoding to Unicode
+
+        if schema.attribute_types is not None:
+            if name not in schema.attribute_types and name not in get_config_parameter('ATTRIBUTES_EXCLUDED_FROM_CHECK'):
+                raise LDAPAttributeError('invalid attribute ' + name)
+
+            # encodes to utf-8 for well known Unicode LDAP syntaxes
+            if auto_encode and (schema.attribute_types[name].syntax in get_config_parameter('UTF8_ENCODED_SYNTAXES') or name in get_config_parameter('UTF8_ENCODED_TYPES')):
+                value = to_unicode(value)  # tries to convert from local encoding to Unicode
+
     return to_raw(value)
 
 


### PR DESCRIPTION
… as None

In some cases, like `foxpass.com` ldap services the schema doesn't return any attribute types and there are `in` statements that are checking against `None` causing it to crash. Added guards around those areas.