### PR TITLE
Test writing byte values

### DIFF
--- a/test/testAddOperation.py
+++ b/test/testAddOperation.py
@@ -44,3 +44,8 @@ class Test(unittest.TestCase):
         self.delete_at_teardown.append(add_user(self.connection, testcase_id, 'add-operation-1'))
 
         self.assertEqual('success', self.delete_at_teardown[0][1]['description'])
+
+    def test_add_bytes(self):
+        self.delete_at_teardown.append(add_user(self.connection, testcase_id, 'add-operation-1', test_bytes=True))
+
+        self.assertEqual('success', self.delete_at_teardown[0][1]['description'])


### PR DESCRIPTION
This is a test that writes byte attribute values. This is suppose to
work, but currently fails.

This is the bare minimum required to fail. Later on might be a good idea to create more tests that pass ``test_bytes=True``.

```
USERDOMAIN=TRAVIS,SYNC,0,EDIR python3 -m nose -s test.testAddOperation
Testing location: TRAVIS,SYNC,0,EDIR
Test server: labldap02.cloudapp.net
Python version: 3.5.3 (default, Jan 19 2017, 14:11:04) 
[GCC 6.3.0 20170118]
Strategy: SYNC - Lazy: False - Check names: True - Collect usage: True
Logging: False - Log detail: None - Fast decoder:  True
.E
======================================================================
ERROR: test_add_bytes (test.testAddOperation.Test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/brian/tree/karaage/ldap3/test/testAddOperation.py", line 49, in test_add_bytes
    self.delete_at_teardown.append(add_user(self.connection, testcase_id, 'add-operation-1', test_bytes=True))
  File "/home/brian/tree/karaage/ldap3/test/__init__.py", line 593, in add_user
    operation_result = connection.add(dn, None, attributes)
  File "/home/brian/tree/karaage/ldap3/ldap3/core/connection.py", line 886, in add
    raise LDAPObjectClassError('invalid object class ' + object_class_name)
TypeError: Can't convert 'bytes' object to str implicitly

----------------------------------------------------------------------
Ran 2 tests in 7.773s

FAILED (errors=1)
```

Obviously I expect travis tests to fail :-)