### PR TITLE
setting attributes explicitly in mockBase

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -394,11 +394,17 @@ class MockBaseStrategy(object):
                 result_code = 0
                 message = 'entry moved'
                 self.connection.server.dit[new_dn]['entryDN'] = [to_raw(new_dn)]
+                new_dn_components = to_dn(new_dn)
+                core_attr, core_val = new_dn_components[0].split('=')
+                self.connection.server.dit[new_dn][core_attr] = [core_val]
             elif new_rdn and not new_superior:  # performs rename
                 new_dn = safe_dn(new_rdn + ',' + safe_dn(dn_components[1:]))
                 self.connection.server.dit[new_dn] = self.connection.server.dit[dn].copy()
                 del self.connection.server.dit[dn]
                 self.connection.server.dit[new_dn]['entryDN'] = [to_raw(new_dn)]
+                new_dn_components = to_dn(new_dn)
+                core_attr, core_val = new_dn_components[0].split('=')
+                self.connection.server.dit[new_dn][core_attr] = [core_val]
                 result_code = 0
                 message = 'entry rdn renamed'
             else:


### PR DESCRIPTION
Hey there,

First off, thanks for this library in the first place, very useful and helpful!

I was working on tests that use the MockSync setup, and most everything worked as expected. The only issue I ran into is during group renames, where the full entry_dn would be set properly, but the `cn` in the attributes/raw would not be updated. I added this little bit of code to get past my issue that you see here.

I'm not going to go so far as to say this is _the_ proper way to do this, but I figured this would be a good place to start the conversation at least. From my understanding/experience, it didn't seem like underlying attributes were being set properly in all instances. Any help/insight would be greatly appreciated.

Thanks!