### PR TITLE
fix decode error in python 3 for uuid

### DIFF
--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -82,7 +82,7 @@ def attributes_to_list(attributes):
 
 
 def ava_to_dict(ava):
-    return {'attribute': str(ava['attributeDesc']), 'value': str(ava['assertionValue'])}
+    return {'attribute': str(ava['attributeDesc']), 'value': ''.join(chr(i) for i in ava['assertionValue']._value)}
 
 
 def substring_to_dict(substring):


### PR DESCRIPTION
When value is uuid, str(ava['assertionValue']) will call decode('utf-8') and raise an exception.