### PR TITLE
Fix bug in MockBaseStrategy.add_entry

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -187,8 +187,9 @@ class MockBaseStrategy(object):
                     if rdn[0] not in new_entry:  # if rdn attribute is missing adds attribute and its value
                         new_entry[rdn[0]] = [to_raw(rdn[1])]
                     else:
-                        if rdn[1] not in new_entry[rdn[0]]:  # add rdn value if rdn attribute is present but value is missing
-                            new_entry[rdn[0]].append(to_raw(rdn[1]))
+                        raw_rdn = to_raw(rdn[1])
+                        if raw_rdn not in new_entry[rdn[0]]:  # add rdn value if rdn attribute is present but value is missing
+                            new_entry[rdn[0]].append(raw_rdn)
                 new_entry['entryDN'] = [to_raw(escaped_dn)]
                 self.connection.server.dit[escaped_dn] = new_entry
                 return True

--- a/test/testMockSyncStrategy.py
+++ b/test/testMockSyncStrategy.py
@@ -318,6 +318,13 @@ class Test(unittest.TestCase):
             result = self.connection_3.result
         self.assertEqual(result['description'], 'entryAlreadyExists')
 
+    def test_add_entry_already_exists_4(self):
+        dn = 'cn=user5,ou=test,o=lab'
+        self.connection_3.bind()
+        self.connection_3.strategy.add_entry(dn, {'objectClass': ['inetOrgPerson', 'top'], 'sn': 'user5_sn', 'cn': 'user5'})
+        result = self.connection_3.server.dit[dn]
+        self.assertEqual(result['cn'], [b'user5'])
+
     def test_delete_entry_nonexisting_1(self):
         dn = 'cn=user5,ou=test,o=lab'
         self.connection_1.bind()


### PR DESCRIPTION
Over at https://github.com/whit537/cloud-custodian/pull/33#issuecomment-312659606 (more or less) I ran into this bug in `add_entry` where we use a text string as a basis for comparison with a byte (raw) string where we should be using the raw version instead.