### PR TITLE
Keep all operations for an attribute in a change, not just the last one

### DIFF
--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -92,7 +92,10 @@ def substring_to_dict(substring):
 def prepare_changes_for_request(changes):
     prepared = dict()
     for change in changes:
-        prepared[change['attribute']['type']] = (change['operation'], change['attribute']['value'])
+        attribute_name = change['attribute']['type']
+        if attribute_name not in prepared:
+            prepared[attribute_name] = []
+        prepared[attribute_name].append((change['operation'], change['attribute']['value']))
     return prepared
 
 


### PR DESCRIPTION
Potential fix for https://github.com/cannatag/ldap3/issues/383
Data in:

    [{'operation': 0, 'attribute': {'type': 'description', 'value': ['hiho']}}, {'operation': 1, 'attribute': {'type': 'description', 'value': ['moo']}}]
Data out before change:

    {'description': (1, ['moo'])}
After change:

    {'description': [(0, ['hiho']), (1, ['moo'])]}

