### PR TITLE
Ensure optional ASN.1 values presence

### DIFF
--- a/ldap3/operation/extended.py
+++ b/ldap3/operation/extended.py
@@ -55,7 +55,7 @@ def extended_operation(request_name,
 
 
 def extended_request_to_dict(request):
-    return {'name': str(request['requestName']), 'value': bytes(request['requestValue']) if request['requestValue'].hasValue() and request['requestValue'] else None}
+    return {'name': str(request['requestName']), 'value': bytes(request['requestValue']) if request['requestValue'] is not None and request['requestValue'].hasValue() else None}
 
 
 def extended_response_to_dict(response):

--- a/ldap3/operation/extended.py
+++ b/ldap3/operation/extended.py
@@ -55,7 +55,7 @@ def extended_operation(request_name,
 
 
 def extended_request_to_dict(request):
-    return {'name': str(request['requestName']), 'value': bytes(request['requestValue']) if request['requestValue'] else None}
+    return {'name': str(request['requestName']), 'value': bytes(request['requestValue']) if request['requestValue'].hasValue() and request['requestValue'] else None}
 
 
 def extended_response_to_dict(response):

--- a/ldap3/operation/modifyDn.py
+++ b/ldap3/operation/modifyDn.py
@@ -51,7 +51,7 @@ def modify_dn_request_to_dict(request):
     return {'entry': str(request['entry']),
             'newRdn': str(request['newrdn']),
             'deleteOldRdn': bool(request['deleteoldrdn']),
-            'newSuperior': str(request['newSuperior']) if request['newSuperior'].hasValue() and request['newSuperior'] else None}
+            'newSuperior': str(request['newSuperior']) if request['newSuperior'] is not None and request['newSuperior'].hasValue() else None}
 
 
 def modify_dn_response_to_dict(response):

--- a/ldap3/operation/modifyDn.py
+++ b/ldap3/operation/modifyDn.py
@@ -51,7 +51,7 @@ def modify_dn_request_to_dict(request):
     return {'entry': str(request['entry']),
             'newRdn': str(request['newrdn']),
             'deleteOldRdn': bool(request['deleteoldrdn']),
-            'newSuperior': str(request['newSuperior']) if request['newSuperior'] else None}
+            'newSuperior': str(request['newSuperior']) if request['newSuperior'].hasValue() and request['newSuperior'] else None}
 
 
 def modify_dn_response_to_dict(response):


### PR DESCRIPTION
Following up [this issue](https://github.com/cannatag/ldap3/issues/385), here is a quick fix aiming at making sure the OPTIONAL ASN.1 value is indeed supplied by the remote end prior to using the value.

Grepping through the sources, I can see more `OptionalNamedType` fields being used. I guess we'd need to apply similar condition to each "read" from these optional fields. WDYT?