### PR TITLE
Check for password correctly in rebind

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -607,7 +607,7 @@ class Connection(object):
         with self.lock:
             if user:
                 self.user = user
-            if password:
+            if password is not None:
                 self.password = password
             if not authentication and user:
                 self.authentication = SIMPLE


### PR DESCRIPTION
Problem: Rebind is comparing making this comparison to validate input data:
```python
if password:
    self.password = password
```
That condition is false in case of `password = ''`, so the old value of the object will be keep in that case, including case where the bind was correct.

This is a potential security hole, since a correct bind followed by a rebind with empty password will complete the binding correctly.

I have changed the way the password is checked to only check if None.