### PR TITLE
Fix compatibility with Twisted on Windows on Python 2.7

### DIFF
--- a/ldap3/core/server.py
+++ b/ldap3/core/server.py
@@ -209,7 +209,7 @@ class Server(object):
     def _is_ipv6(host):
         try:
             socket.inet_pton(socket.AF_INET6, host)
-        except (socket.error, AttributeError):
+        except (socket.error, AttributeError, ValueError):
             return False
         return True
 


### PR DESCRIPTION
On Windows, socket.inet_pton is implemented since Python 3.4.
Twisted has compatibility layer that implements socket.inet_pton also for 2.7.
In case of error it raises ValueError exception https://github.com/twisted/twisted/blob/trunk/src/twisted/python/compat.py#L99

This pull request fixes compatibility with Twisted app running on Windows with python 2.7.
This was discovered with Buildbot running on Windows discussed here https://github.com/buildbot/buildbot/pull/3569