### PR TITLE
Fix auto_encode check in validate_attribute_value for unknown attrs.

### DIFF
--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -156,7 +156,10 @@ def validate_attribute_value(schema, name, value, auto_encode):
             raise LDAPAttributeError('invalid attribute ' + name)
 
         # converts to utf-8 for well known Unicode LDAP syntaxes
-        if auto_encode and (schema.attribute_types[name].syntax in conf_utf8_syntaxes or name.lower() in conf_utf8_types):
+        if auto_encode and ((name in schema.attribute_types and
+                            schema.attribute_types[name].syntax
+                            in conf_utf8_syntaxes) or name.lower() in
+                            conf_utf8_types):
             value = to_unicode(value)  # tries to convert from local encoding to Unicode
     # checks for boolean value and sets it to LDAP standard boolean string
     if isinstance(value, bool):


### PR DESCRIPTION
For attributes which are not included in the server schema
add a test for ``name in schema.attribute_types`` to avoid KeyErrors
when checking for auto encoding. This is especially the case
for the 'memberofgroupattr' attribute which is e.g. necessary for
configuring memberOf plugins in 389ds instances.