### PR TITLE
Allow installing ldap3 compiled to C using cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 
 # C extensions
 *.so
+# Cythonized .c files
+*.c
 
 # Distribution / packaging
 .Python

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from setuptools import setup
 from json import load
 
@@ -38,24 +39,115 @@ package_folder = str(version_dict['package_folder'])
 status = str(version_dict['status'])
 
 long_description = str(open('README.rst').read())
+packages=['ldap3',
+          'ldap3.abstract',
+          'ldap3.core',
+          'ldap3.operation',
+          'ldap3.protocol',
+          'ldap3.protocol.sasl',
+          'ldap3.protocol.schemas',
+          'ldap3.protocol.formatters',
+          'ldap3.strategy',
+          'ldap3.utils',
+          'ldap3.extend',
+          'ldap3.extend.novell',
+          'ldap3.extend.microsoft',
+          'ldap3.extend.standard']
+
+setup_kwargs = {'packages': packages,
+                'package_dir': {'': package_folder}}
+
+try:
+    from Cython.Build import cythonize
+    HAS_CYTHON = True
+except ImportError:
+    HAS_CYTHON = False
+
+if 'LDAP3_CYTHON_COMPILE' in os.environ and HAS_CYTHON is True:
+    import sys
+    import multiprocessing
+    import multiprocessing.pool
+    from setuptools import Extension
+    from distutils.command.build_py import build_py
+    from distutils.command.build_ext import build_ext
+    # Change to source's directory prior to running any command
+    try:
+        SETUP_DIRNAME = os.path.dirname(__file__)
+    except NameError:
+        # We're most likely being frozen and __file__ triggered this NameError
+        # Let's work around that
+        SETUP_DIRNAME = os.path.dirname(sys.argv[0])
+    if SETUP_DIRNAME != '':
+        os.chdir(SETUP_DIRNAME)
+
+    SETUP_DIRNAME = os.path.abspath(SETUP_DIRNAME)
+
+    def find_ext():
+        for package in ('ldap3',):
+            for root, _, files in os.walk(os.path.join(SETUP_DIRNAME, package)):
+                commonprefix = os.path.commonprefix([SETUP_DIRNAME, root])
+                for filename in files:
+                    full = os.path.join(root, filename)
+                    if not filename.endswith(('.py', '.c')):
+                        continue
+                    if filename in ('__init__.py',):
+                        continue
+                    relpath = os.path.join(root, filename).split(commonprefix)[-1][1:]
+                    module = os.path.splitext(relpath)[0].replace(os.sep, '.')
+                    yield Extension(module, [full])
+
+    def discover_packages():
+        modules = []
+        pkg_data = {}
+        pkg_dir = {}
+        for package in ('ldap3',):
+            for root, _, files in os.walk(os.path.join(SETUP_DIRNAME, package)):
+                if '__init__.py' not in files:
+                    continue
+                pdir = os.path.relpath(root, SETUP_DIRNAME)
+                modname = pdir.replace(os.sep, '.')
+                modules.append(modname)
+                pkg_data.setdefault(modname, []).append('*.so')
+                pkg_dir[modname] = pdir
+        return modules, pkg_dir, pkg_data
+
+    ext_modules = cythonize(list(find_ext()), nthreads=multiprocessing.cpu_count())
+
+
+    class BuildPy(build_py):
+
+        def find_package_modules(self, package, package_dir):
+            modules = build_py.find_package_modules(self, package, package_dir)
+            for package, module, filename in modules:
+                if module not in ('__init__',):
+                    # We only want __init__ python files
+                    # All others will be built as extensions
+                    continue
+                yield package, module, filename
+
+
+    class BuildExt(build_ext):
+
+        def run(self):
+            self.extensions = ext_modules
+            build_ext.run(self)
+
+        def build_extensions(self):
+            multiprocessing.pool.ThreadPool(
+                processes=multiprocessing.cpu_count()).map(
+                    self.build_extension, self.extensions)
+
+    packages, package_dir, package_data = discover_packages()
+    setup_kwargs['packages'] = packages
+    setup_kwargs['package_dir'] = package_dir
+    setup_kwargs['package_data'] = package_data
+    setup_kwargs['cmdclass'] = {'build_py': BuildPy, 'build_ext': BuildExt}
+    setup_kwargs['ext_modules'] = ext_modules
+    setup_kwargs['zip_safe'] = False
+
 
 setup(name=package_name,
       version=version,
-      packages=['ldap3',
-                'ldap3.abstract',
-                'ldap3.core',
-                'ldap3.operation',
-                'ldap3.protocol',
-                'ldap3.protocol.sasl',
-                'ldap3.protocol.schemas',
-                'ldap3.protocol.formatters',
-                'ldap3.strategy',
-                'ldap3.utils',
-                'ldap3.extend',
-                'ldap3.extend.novell',
-                'ldap3.extend.microsoft',
-                'ldap3.extend.standard'],
-      package_dir={'': package_folder},
       install_requires=[i.strip() for i in open('requirements.txt').readlines()],
       license=license,
       author=author,
@@ -75,5 +167,6 @@ setup(name=package_name,
                    'Programming Language :: Python :: 2',
                    'Programming Language :: Python :: 3',
                    'Topic :: Software Development :: Libraries :: Python Modules',
-                   'Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP']
+                   'Topic :: System :: Systems Administration :: Authentication/Directory :: LDAP'],
+      **setup_kwargs
       )


### PR DESCRIPTION
There's no cython specific code in the package so we don't take much
advantage from cython, but running from compiled C code, even in this
scenario has proven to be at least a bit more performant.