### PR TITLE
validate SSL by default

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -174,7 +174,7 @@ class Tls(object):
                                                      cafile=self.ca_certs_file,
                                                      capath=self.ca_certs_path,
                                                      cadata=self.ca_certs_data)
-            else:  # code from create_default_context in the Python standard library 3.5.1, creates a ssl context with the specificd protocol version
+            else:  # code from create_default_context in the Python standard library 3.5.1, creates a ssl context with the specified protocol version
                 ssl_context = ssl.SSLContext(self.version)
                 if self.ca_certs_file or self.ca_certs_path or self.ca_certs_data:
                     ssl_context.load_verify_locations(self.ca_certs_file, self.ca_certs_path, self.ca_certs_data)

--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -69,7 +69,7 @@ class Tls(object):
     def __init__(self,
                  local_private_key_file=None,
                  local_certificate_file=None,
-                 validate=ssl.CERT_NONE,
+                 validate=ssl.CERT_REQUIRED,
                  version=None,
                  ca_certs_file=None,
                  valid_names=None,


### PR DESCRIPTION
It should be good practice in 2018 to validate SSL certificates by default, and require the user to disable this explicitly if a validation should NOT be performed.