### PR TITLE
Make entry membership check return false if entry doesn't contain item key

### DIFF
--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -147,7 +147,7 @@ class EntryBase(object):
         try:
             self.__getitem__(item)
             return True
-        except LDAPKeyError:
+        except (LDAPKeyError, LDAPCursorError):
             return False
 
     def __getattr__(self, item):


### PR DESCRIPTION
The EntryBase class's __contains__ method checks if an entry contains an item by trying to get it with __getitem__. If the attribute is not found by line 234, then __getitem__ raises an LDAPCursorError exception with the message that the key was not found.

It seems that if the item's key was not found, then __contains__ should return False rather than propagating the exception.