### PR TITLE
Possible fix for search filters involving objectGUID

### DIFF
--- a/ldap3/utils/conv.py
+++ b/ldap3/utils/conv.py
@@ -88,12 +88,15 @@ def escape_filter_chars(text, encoding=None):
     if encoding is None:
         encoding = get_config_parameter('DEFAULT_ENCODING')
 
-    text = to_unicode(text, encoding)
-    escaped = text.replace('\\', '\\5c')
-    escaped = escaped.replace('*', '\\2a')
-    escaped = escaped.replace('(', '\\28')
-    escaped = escaped.replace(')', '\\29')
-    escaped = escaped.replace('\x00', '\\00')
+    try:
+        text = to_unicode(text, encoding)
+        escaped = text.replace('\\', '\\5c')
+        escaped = escaped.replace('*', '\\2a')
+        escaped = escaped.replace('(', '\\28')
+        escaped = escaped.replace(')', '\\29')
+        escaped = escaped.replace('\x00', '\\00')
+    except UnicodeError:
+        escaped = escape_bytes(text)
     # escape all octets greater than 0x7F that are not part of a valid UTF-8
     # escaped = ''.join(c if c <= '\x7f' else escape_bytes(to_raw(to_unicode(c, encoding))) for c in output)
     return escaped


### PR DESCRIPTION
Hi @cannatag, I had a look into the ldap3 source and tried to find a fix for #482. This is what I came up with:

The exception is raised because ``filter_to_string`` tries to re-build the filter string from a filter object. The assertion values in the filter objects are bytestrings and ``escape_filter_chars`` assumes them to be valid UTF-8. Apparently, this is correct most of the time, but fails in the case of ``objectGUID``, because here, the bytestring is actually a sequence of arbitrary octets.

My workaround just catches the unicode exception and escapes the whole sequence of octets in that case. This is the behavior I would expect in the case of objectGUID.

So, this fixes #482 for me, but honestly I do not know enough about the LDAP RFCs or ldap3 to judge whether this is a good idea. If you would prefer another way to fix this, just let me know and I'm happy to come up with another PR. :)

Thanks a lot for your great work!