### PR TITLE
Fix substring filter with unicode values

### DIFF
--- a/ldap3/operation/search.py
+++ b/ldap3/operation/search.py
@@ -487,6 +487,7 @@ def filter_to_string(filter_object):
                     filter_string += '*'
                 elif component == 'final':
                     filter_string += '*' + str(substring['final'])
+        filter_string = to_unicode(filter_string)
     elif filter_type == 'greaterOrEqual':
         ava = ava_to_dict(filter_object['greaterOrEqual'])
         filter_string += ava['attribute'] + '>=' + ava['value']


### PR DESCRIPTION
Hi Giovanni,

I noticed that using a substring filter which contains non-ASCII characters in a compound filter (like ``(&(...))``) throws an exception on current master and dev.

Here is an example:
```python
# coding: utf-8

from ldap3 import Server, Connection, ALL
server = Server('ipa.demo1.freeipa.org', get_info=ALL)
conn = Connection(server, 'uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org', 'Secret123', auto_bind=True)
conn.search('dc=demo1,dc=freeipa,dc=org', u'(&(objectClass=person)(uid=ö*))')
print conn.response
```
and the exception:
```
$ python unicode-bug.py
Traceback (most recent call last):
  File "unicode-bug.py", line 6, in <module>
    conn.search('dc=demo1,dc=freeipa,dc=org', u'(&(objectClass=person)(uid=ö*))')
  File "/home/fred/privacyidea/ldap3/ldap3/core/connection.py", line 775, in search
    response = self.post_send_search(self.send('searchRequest', request, controls))
  File "/home/fred/privacyidea/ldap3/ldap3/strategy/base.py", line 303, in send
    self.connection.request = BaseStrategy.decode_request(message_type, request, controls)
  File "/home/fred/privacyidea/ldap3/ldap3/strategy/base.py", line 635, in decode_request
    result = search_request_to_dict(component)
  File "/home/fred/privacyidea/ldap3/ldap3/operation/search.py", line 516, in search_request_to_dict
    'filter': filter_to_string(request['filter']),
  File "/home/fred/privacyidea/ldap3/ldap3/operation/search.py", line 466, in filter_to_string
    filter_string += filter_to_string(f)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 5: ordinal not in range(128)
```

I attempted a fix in this pull request. But as always, I'm not at all sure if that's the best way to do it :-)

Let me know if I can be of any help!

Thank you and Best Wishes

Friedrich