### PR TITLE
Fix duplicate controls

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -747,6 +747,9 @@ class Connection(object):
 
                 if controls is None:
                     controls = []
+                else:
+                    # Copy the controls to prevent modifying the original object
+                    controls = list(controls)
                 controls.append(paged_search_control(paged_criticality, paged_size, paged_cookie))
 
             if self.server and self.server.schema and self.check_names:


### PR DESCRIPTION
The current version has a bug that if `controls` are specified to a paged search, the page control is appended to the controls. This works only for the first page since the second page will have 2 `paged_search_control`s in the `controls` list and results in an `LDAPProtocolErrorResult`: `Error processing control`.
The patch provided copies the list to a new object and thus the `.append` will not modify it, and the original `controls` object will be used again for the next page.