### PR TITLE
Doc updates for how to get dn

### DIFF
--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -115,7 +115,7 @@ class EntryBase(object):
 
     The Entry object is read only
 
-    - The DN is retrieved by _dn
+    - The DN is retrieved by entry_dn
     - The cursor reference is in _cursor
     - Raw attributes values are retrieved with _raw_attributes and the _raw_attribute() methods
     """
@@ -355,7 +355,7 @@ class Entry(EntryBase):
 
     The Entry object is read only
 
-    - The DN is retrieved by _dn()
+    - The DN is retrieved by entry_dn
     - The Reader reference is in _cursor()
     - Raw attributes values are retrieved by the _ra_attributes and
       _raw_attribute() methods


### PR DESCRIPTION
The current information for getting a dn is not correct, instead of `entry._dn` as the documentation currently says it should be `entry.entry_dn`