### PR TITLE
pass exceptions from PooledConnectionThread to client thread

### DIFF
--- a/ldap3/strategy/reusable.py
+++ b/ldap3/strategy/reusable.py
@@ -238,21 +238,21 @@ class ReusableStrategy(BaseStrategy):
                             if log_enabled(BASIC):
                                 log(BASIC, 'thread respawn')
                         if message_type not in ['bindRequest', 'unbindRequest']:
-                            if pool.open_pool and self.worker.connection.closed:
-                                self.worker.connection.open(read_server_info=False)
-                                if pool.tls_pool and not self.worker.connection.tls_started:
-                                    self.worker.connection.start_tls(read_server_info=False)
-                                if pool.bind_pool and not self.worker.connection.bound:
-                                    self.worker.connection.bind(read_server_info=False)
-                            elif pool.open_pool and not self.worker.connection.closed:  # connection already open, issues a start_tls
-                                if pool.tls_pool and not self.worker.connection.tls_started:
-                                    self.worker.connection.start_tls(read_server_info=False)
-                            if self.worker.get_info_from_server and counter:
-                                self.worker.connection._fire_deferred()
-                                self.worker.get_info_from_server = False
-                            response = None
-                            result = None
                             try:
+                                if pool.open_pool and self.worker.connection.closed:
+                                    self.worker.connection.open(read_server_info=False)
+                                    if pool.tls_pool and not self.worker.connection.tls_started:
+                                        self.worker.connection.start_tls(read_server_info=False)
+                                    if pool.bind_pool and not self.worker.connection.bound:
+                                        self.worker.connection.bind(read_server_info=False)
+                                elif pool.open_pool and not self.worker.connection.closed:  # connection already open, issues a start_tls
+                                    if pool.tls_pool and not self.worker.connection.tls_started:
+                                        self.worker.connection.start_tls(read_server_info=False)
+                                if self.worker.get_info_from_server and counter:
+                                    self.worker.connection._fire_deferred()
+                                    self.worker.get_info_from_server = False
+                                response = None
+                                result = None
                                 if message_type == 'searchRequest':
                                     response = self.worker.connection.post_send_search(self.worker.connection.send(message_type, request, controls))
                                 else:


### PR DESCRIPTION
Exceptions thrown during open(), start_tls() and bind() can reach the
top of the call stack of the pool thread without the client thread being
notified. This results in a traceback and makes handling those errors by
the client impossible.

This patch catches those exceptions too, and passes them to the client
thread just like errors arising while performing LDAP requests.