### PR TITLE
Add more detailed info about invalid value when using Mock strategy

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -200,7 +200,11 @@ class MockBaseStrategy(object):
                 value = validated
         raw_value = to_raw(value)
         if not isinstance(raw_value, bytes):
-            raise LDAPInvalidValueError('added values must be bytes if no offline schema is provided in Mock strategies')
+            raise LDAPInvalidValueError('The value "%s" of type %s for "%s" must be bytes or an offline schema needs to be provided when Mock strategy is used.' % (
+                value,
+                type(value),
+                attribute_type,
+            ))
         return raw_value
 
     def _update_attribute(self, dn, attribute_type, value):


### PR DESCRIPTION
The error message "added values must be bytes if no offline schema is
provided in Mock strategies" is not very informative when you get
that error while writing tests for your own code; you need to dive
into ldap3 implementation to see that the real issues is that the
type of some field has invalid type (not numeric, string or sequence
type).