### PR TITLE
malformatted GUID when used in filters

### DIFF
--- a/ldap3/protocol/convert.py
+++ b/ldap3/protocol/convert.py
@@ -183,7 +183,7 @@ def prepare_filter_for_sending(raw_string):
     ints = []
     raw_string = to_raw(raw_string)
     while i < len(raw_string):
-        if (raw_string[i] == 92 or raw_string[i] == '\\') and i < len(raw_string) - 2:  # 92 is backslash
+        if (raw_string[i] == 92 or raw_string[i] == '\\') and i < len(raw_string) - 2 and (raw_string[i+1] == 120 or raw_string[i+1] == 'x'):  # 92 is backslash
             try:
                 ints.append(int(raw_string[i + 1: i + 3], 16))
                 i += 2


### PR DESCRIPTION
added condition to take into consideration if 'x' is following '\\' when preparing filters.  in some scenearios like objectGuid 294cf255-828c-43fd-8e61-36315c2b6237 the byte array legitimately has '\\' as a valid byte that is not hex formatted value

example filter (objectGuid=294cf255-828c-43fd-8e61-36315c2b6237)
the prepared filter value should be 0x55F24C298C82FD438E6136315C2B6237 
but instead is 0x55f24c298c82fd438e6136310b37
