### PR TITLE
doc: fix SASL reference in bind example

### DIFF
--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -180,7 +180,7 @@ Kerberos authentication uses the ``gssapi`` package. You must install it and con
     tls = Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2)
     server = Server('<servername>', use_ssl=True, tls=tls)
     c = Connection(
-        server, authentication=ldap3.SASL, sasl_mechanism=KERBEROS)
+        server, authentication=SASL, sasl_mechanism=KERBEROS)
     c.bind()
     print(c.extend.standard.who_am_i())
 


### PR DESCRIPTION
The first line of this example imports the `SASL` value directly from ldap3, so we should not refer to this as `ldap3.SASL` in the code later on.