### PR TITLE
Support formatting Active Directory time deltas

### DIFF
--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -324,6 +324,19 @@ except ImportError:
         return raw_value
 
 
+def format_ad_timedelta(raw_value):
+    """
+    Convert a negative filetime value to a timedelta.
+    """
+    # Active Directory stores attributes like "minPwdAge" as a negative
+    # "filetime" timestamp, which is the number of 100-nanosecond intervals that
+    # have elapsed since the 0 hour on January 1, 1601. By making the number
+    # positive, we can reuse format_ad_timestamp to get a datetime object.
+    # Afterwards, we can subtract a datetime representing 0 hour on January 1,
+    # 1601 from the returned datetime to get the timedelta.
+    return format_ad_timestamp(raw_value * -1) - format_ad_timestamp(0)
+
+
 def format_time_with_0_year(raw_value):
     try:
         if raw_value.startswith(b'0000'):

--- a/ldap3/protocol/formatters/standard.py
+++ b/ldap3/protocol/formatters/standard.py
@@ -25,10 +25,12 @@
 
 from ... import SEQUENCE_TYPES
 from .formatters import format_ad_timestamp, format_binary, format_boolean,\
-    format_integer, format_sid, format_time, format_unicode, format_uuid, format_uuid_le, format_time_with_0_year
+    format_integer, format_sid, format_time, format_unicode, format_uuid, format_uuid_le, format_time_with_0_year,\
+    format_ad_timedelta
 from .validators import validate_integer, validate_time, always_valid,\
     validate_generic_single_value, validate_boolean, validate_ad_timestamp, validate_sid,\
-    validate_uuid_le, validate_uuid, validate_zero_and_minus_one_and_positive_int, validate_guid, validate_time_with_0_year
+    validate_uuid_le, validate_uuid, validate_zero_and_minus_one_and_positive_int, validate_guid, validate_time_with_0_year,\
+    validate_ad_timedelta
 
 # for each syntax can be specified a format function and a input validation function
 
@@ -121,6 +123,9 @@ standard_formatter = {
     '1.2.840.113556.1.4.49': (format_ad_timestamp, validate_ad_timestamp),  # badPasswordTime (Microsoft)
     '1.2.840.113556.1.4.51': (format_ad_timestamp, validate_ad_timestamp),  # lastLogoff (Microsoft)
     '1.2.840.113556.1.4.52': (format_ad_timestamp, validate_ad_timestamp),  # lastLogon (Microsoft)
+    '1.2.840.113556.1.4.60': (format_ad_timedelta, validate_ad_timedelta),  # lockoutDuration (Microsoft)
+    '1.2.840.113556.1.4.74': (format_ad_timedelta, validate_ad_timedelta),  # maxPwdAge (Microsoft)
+    '1.2.840.113556.1.4.78': (format_ad_timedelta, validate_ad_timedelta),  # minPwdAge (Microsoft)
     '1.2.840.113556.1.4.96': (format_ad_timestamp, validate_zero_and_minus_one_and_positive_int),  # pwdLastSet (Microsoft, can be set to -1 only)
     '1.2.840.113556.1.4.146': (format_sid, validate_sid),  # objectSid (Microsoft)
     '1.2.840.113556.1.4.159': (format_ad_timestamp, validate_ad_timestamp),  # accountExpires (Microsoft)

--- a/ldap3/protocol/formatters/validators.py
+++ b/ldap3/protocol/formatters/validators.py
@@ -258,6 +258,14 @@ def validate_ad_timestamp(input_value):
     else:
         return True
 
+def validate_ad_timedelta(input_value):
+    """
+    Should be validated like an AD timestamp except that since it is a time
+    delta, it is stored as a negative number.
+    """
+    if not isinstance(input_value, int) or input_value > 0:
+        return False
+    return validate_ad_timestamp(input_value * -1)
 
 def validate_guid(input_value):
     """

--- a/test/testFormatters.py
+++ b/test/testFormatters.py
@@ -1,0 +1,12 @@
+import unittest
+from datetime import timedelta
+
+from ldap3.protocol.formatters.formatters import format_ad_timedelta
+
+
+class TestFormatters(unittest.TestCase):
+    def test_format_ad_timedelta_thirty_mins(self):
+        self.assertEqual(format_ad_timedelta(-18000000000), timedelta(minutes=30))
+
+    def test_format_ad_timedelta_one_day(self):
+        self.assertEqual(format_ad_timedelta(-864000000000), timedelta(days=1))

--- a/test/testValidators.py
+++ b/test/testValidators.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int
+from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int, validate_ad_timedelta
 from ldap3.core.timezone import OffsetTzInfo
 
 class Test(unittest.TestCase):
@@ -202,3 +202,9 @@ class Test(unittest.TestCase):
         self.assertTrue(validated)
         validated = validate_zero_and_minus_one_and_positive_int('-2')
         self.assertFalse(validated)
+
+    def test_validate_ad_timedelta_valid(self):
+        self.assertTrue(validate_ad_timedelta(-36288000000000))
+
+    def test_validate_ad_timedelta_invalid(self):
+        self.assertFalse(validate_ad_timedelta(123))


### PR DESCRIPTION
There are a few LDAP attributes that are stored on an Active Directory domain object that are negative "file time" values that represent time deltas. This PR formats these to Python time deltas for convenience.

I couldn't verify that the tests actually pass though because when I run the tests locally, I get the message `ERROR: Failure: Exception (testing location UNKNOWN-EDIR is not valid)`.