### PR TITLE
Wrap response_name in OctetString in mock_extended

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -724,12 +724,12 @@ class MockBaseStrategy(object):
                     if extension[0] == '2.16.840.1.113719.1.27.100.31':  # getBindDNRequest [NOVELL]
                         result_code = 0
                         message = ''
-                        response_name = '2.16.840.1.113719.1.27.100.32'  # getBindDNResponse [NOVELL]
+                        response_name = OctetString('2.16.840.1.113719.1.27.100.32')  # getBindDNResponse [NOVELL]
                         response_value = OctetString(self.bound)
                     elif extension[0] == '1.3.6.1.4.1.4203.1.11.3':  # WhoAmI [RFC4532]
                         result_code = 0
                         message = ''
-                        response_name = '1.3.6.1.4.1.4203.1.11.3'  # WhoAmI [RFC4532]
+                        response_name = OctetString('1.3.6.1.4.1.4203.1.11.3')  # WhoAmI [RFC4532]
                         response_value = OctetString(self.bound)
                     break
 


### PR DESCRIPTION
With the changes to ldap3/operation/extended.py in 6698d591d2a7b6efb961e916d14e0c5ae99ee198, introduced in 2.5.1, mock_extended in mockBase.py can no longer return the response_name as a simple string, and must return it as a OctetString instead.
