### PR TITLE
adds the option to raise an error in extend.microsoft package for gro…

### DIFF
--- a/ldap3/extend/microsoft/addMembersToGroups.py
+++ b/ldap3/extend/microsoft/addMembersToGroups.py
@@ -1,6 +1,7 @@
 """
 """
 
+from ... import SEQUENCE_TYPES, MODIFY_ADD, BASE, DEREF_NEVER
 # Created on 2016.12.26
 #
 # Author: Giovanni Cannata
@@ -22,19 +23,20 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
-from ...core.exceptions import LDAPInvalidDnError
-from ... import SEQUENCE_TYPES, MODIFY_ADD, BASE, DEREF_NEVER
+from ...core.exceptions import LDAPInvalidDnError, LDAPOperationsErrorResult
 
 
 def ad_add_members_to_groups(connection,
                              members_dn,
                              groups_dn,
-                             fix=True):
+                             fix=True,
+                             raise_error=False):
     """
     :param connection: a bound Connection object
     :param members_dn: the list of members to add to groups
     :param groups_dn: the list of groups where members are to be added
     :param fix: checks for group existence and already assigned members
+    :param raise_error: If the operation fails it raises an error instead of returning False
     :return: a boolean where True means that the operation was successful and False means an error has happened
     Establishes users-groups relations following the Active Directory rules: users are added to the member attribute of groups.
     Raises LDAPInvalidDnError if members or groups are not found in the DIT.
@@ -49,7 +51,8 @@ def ad_add_members_to_groups(connection,
     error = False
     for group in groups_dn:
         if fix:  # checks for existance of group and for already assigned members
-            result = connection.search(group, '(objectclass=*)', BASE, dereference_aliases=DEREF_NEVER, attributes=['member'])
+            result = connection.search(group, '(objectclass=*)', BASE, dereference_aliases=DEREF_NEVER,
+                                       attributes=['member'])
 
             if not connection.strategy.sync:
                 response, result = connection.get_response(result)
@@ -76,6 +79,9 @@ def ad_add_members_to_groups(connection,
                 result = connection.result
             if result['description'] != 'success':
                 error = True
+                result_error_params = ['result', 'description', 'dn', 'message']
+                if raise_error:
+                    raise LDAPOperationsErrorResult(**{k: v for k, v in result.items() if k in result_error_params})
                 break
 
     return not error  # returns True if no error is raised in the LDAP operations

--- a/ldap3/extend/microsoft/removeMembersFromGroups.py
+++ b/ldap3/extend/microsoft/removeMembersFromGroups.py
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
-from ...core.exceptions import LDAPInvalidDnError
+from ...core.exceptions import LDAPInvalidDnError, LDAPOperationsErrorResult
 from ... import SEQUENCE_TYPES, MODIFY_DELETE, BASE, DEREF_NEVER
 from ...utils.dn import safe_dn
 
@@ -30,12 +30,14 @@ from ...utils.dn import safe_dn
 def ad_remove_members_from_groups(connection,
                                   members_dn,
                                   groups_dn,
-                                  fix):
+                                  fix,
+                                  raise_error=False):
     """
     :param connection: a bound Connection object
     :param members_dn: the list of members to remove from groups
     :param groups_dn: the list of groups where members are to be removed
     :param fix: checks for group existence and existing members
+    :param raise_error: If the operation fails it raises an error instead of returning False
     :return: a boolean where True means that the operation was successful and False means an error has happened
     Removes users-groups relations following the Activwe Directory rules: users are removed from groups' member attribute
 
@@ -88,6 +90,9 @@ def ad_remove_members_from_groups(connection,
                 result = connection.result
             if result['description'] != 'success':
                 error = True
+                result_error_params = ['result', 'description', 'dn', 'message']
+                if raise_error:
+                    raise LDAPOperationsErrorResult(**{k: v for k, v in result.items() if k in result_error_params})
                 break
 
     return not error


### PR DESCRIPTION
Addresses #569 .
Adds additional parameter for `ldap3.extend.microsoft.addMembersToGroups` and `ldap3.extend.microsoft.removeMembersFromGroups` to raise an error in case of failure. The boolean value returned by the actual package can be very difficult to troubleshoot in case of problems.