### PR TITLE
Fix WhoAmI calls using the mock LDAP instance

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -724,12 +724,12 @@ class MockBaseStrategy(object):
                     if extension[0] == '2.16.840.1.113719.1.27.100.31':  # getBindDNRequest [NOVELL]
                         result_code = 0
                         message = ''
-                        response_name = '2.16.840.1.113719.1.27.100.32'  # getBindDNResponse [NOVELL]
+                        response_name = OctetString('2.16.840.1.113719.1.27.100.32')  # getBindDNResponse [NOVELL]
                         response_value = OctetString(self.bound)
                     elif extension[0] == '1.3.6.1.4.1.4203.1.11.3':  # WhoAmI [RFC4532]
                         result_code = 0
                         message = ''
-                        response_name = '1.3.6.1.4.1.4203.1.11.3'  # WhoAmI [RFC4532]
+                        response_name = OctetString('1.3.6.1.4.1.4203.1.11.3')  # WhoAmI [RFC4532]
                         response_value = OctetString(self.bound)
                     break
 


### PR DESCRIPTION
The `extended_response_to_dict` function expects the `responseValue` to be an `OctetString` but before this change, the mock LDAP instance would return a normal string and the `extended_response_to_dict` function would fail when trying to call `hasValue` on the string.