### PR TITLE
Prevented unnecessary raising of an error.

### DIFF
--- a/ldap3/extend/standard/modifyPassword.py
+++ b/ldap3/extend/standard/modifyPassword.py
@@ -67,6 +67,6 @@ class ModifyPassword(ExtendedOperation):
                 self.result[self.response_attribute] = True
             else:  # change was not successful, raises exception if raise_exception = True in connection or returns the operation result, error code is in result['result']
                 self.result[self.response_attribute] = False
-                if not self.connection.raise_exceptions:
+                if self.connection.raise_exceptions:
                     from ...core.exceptions import LDAPOperationResult
                     raise LDAPOperationResult(result=self.result['result'], description=self.result['description'], dn=self.result['dn'], message=self.result['message'], response_type=self.result['type'])


### PR DESCRIPTION
- The comment above the code suggested that an error should only be raised if: `raise_exception == True`, however an exception was raised whether **raise_exception** was _True_ or _False_.