### PR TITLE
strategy/reusable: correctly refresh server info

### DIFF
--- a/ldap3/strategy/reusable.py
+++ b/ldap3/strategy/reusable.py
@@ -249,7 +249,7 @@ class ReusableStrategy(BaseStrategy):
                                     if pool.tls_pool and not self.worker.connection.tls_started:
                                         self.worker.connection.start_tls(read_server_info=False)
                                 if self.worker.get_info_from_server and counter:
-                                    self.worker.connection._fire_deferred()
+                                    self.worker.connection.refresh_server_info()
                                     self.worker.get_info_from_server = False
                                 response = None
                                 result = None


### PR DESCRIPTION
It turns out that Connection._fire_deferred() is a no-op for non-lazy
connections. Because of this the pooled connections of ReusableStrategy
do not correctly get their schema refreshed when
Connection.refresh_server_info() is called on a connection with reusable
strategy.

This causes performing operations without the schema being present if we're
using ServerPool() with multiple servers and leads to unexpected types
returned by Connection.search().

References: jira PAM-7321