### PR TITLE
core/pooling: use a namedtuple to store server state

### DIFF
--- a/ldap3/core/pooling.py
+++ b/ldap3/core/pooling.py
@@ -23,6 +23,7 @@
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
 
+from collections import namedtuple
 from datetime import datetime, MINYEAR
 from os import linesep
 from random import randint
@@ -36,9 +37,12 @@ from ..utils.log import log, log_enabled, ERROR, BASIC, NETWORK
 POOLING_STRATEGIES = [FIRST, ROUND_ROBIN, RANDOM]
 
 
+ServerState = namedtuple('ServerState', ['server', 'last_checked_time', 'available'])
+
+
 class ServerPoolState(object):
     def __init__(self, server_pool):
-        self.servers = []  # each element is a list: [server, last_checked_time, available]
+        self.server_states = []  # each element is a ServerState
         self.strategy = server_pool.strategy
         self.server_pool = server_pool
         self.last_used_server = 0
@@ -50,27 +54,27 @@ class ServerPoolState(object):
 
     def __str__(self):
         s = 'servers: ' + linesep
-        if self.servers:
-            for server in self.servers:
-                s += str(server[0]) + linesep
+        if self.server_states:
+            for state in self.server_states:
+                s += str(state.server) + linesep
         else:
             s += 'None' + linesep
         s += 'Pool strategy: ' + str(self.strategy) + linesep
-        s += ' - Last used server: ' + ('None' if self.last_used_server == -1 else str(self.servers[self.last_used_server][0]))
+        s += ' - Last used server: ' + ('None' if self.last_used_server == -1 else str(self.server_states[self.last_used_server].server))
 
         return s
 
     def refresh(self):
-        self.servers = []
+        self.server_states = []
         for server in self.server_pool.servers:
-            self.servers.append([server, datetime(MINYEAR, 1, 1), True])  # server, smallest date ever, supposed available
-        self.last_used_server = randint(0, len(self.servers) - 1)
+            self.server_states.append(ServerState(server, datetime(MINYEAR, 1, 1), True))  # server, smallest date ever, supposed available
+        self.last_used_server = randint(0, len(self.server_states) - 1)
 
     def get_current_server(self):
-        return self.servers[self.last_used_server][0]
+        return self.server_states[self.last_used_server].server
 
     def get_server(self):
-        if self.servers:
+        if self.server_states:
             if self.server_pool.strategy == FIRST:
                 if self.server_pool.active:
                     # returns the first active server
@@ -84,20 +88,20 @@ class ServerPoolState(object):
                     self.last_used_server = self.find_active_server(self.last_used_server + 1)
                 else:
                     # returns the next server in a circular range
-                    self.last_used_server = self.last_used_server + 1 if (self.last_used_server + 1) < len(self.servers) else 0
+                    self.last_used_server = self.last_used_server + 1 if (self.last_used_server + 1) < len(self.server_states) else 0
             elif self.server_pool.strategy == RANDOM:
                 if self.server_pool.active:
                     self.last_used_server = self.find_active_random_server()
                 else:
                     # returns a random server in the pool
-                    self.last_used_server = randint(0, len(self.servers) - 1)
+                    self.last_used_server = randint(0, len(self.server_states) - 1)
             else:
                 if log_enabled(ERROR):
                     log(ERROR, 'unknown server pooling strategy <%s>', self.server_pool.strategy)
                 raise LDAPUnknownStrategyError('unknown server pooling strategy')
             if log_enabled(BASIC):
                 log(BASIC, 'server returned from Server Pool: <%s>', self.last_used_server)
-            return self.servers[self.last_used_server][0]
+            return self.server_states[self.last_used_server].server
         else:
             if log_enabled(ERROR):
                 log(ERROR, 'no servers in Server Pool <%s>', self)
@@ -108,27 +112,27 @@ class ServerPoolState(object):
         while counter:
             if log_enabled(NETWORK):
                 log(NETWORK, 'entering loop for finding active server in pool <%s>', self)
-            temp_list = self.servers[:]  # copy
+            temp_list = self.server_states[:]  # copy
             while temp_list:
                 # pops a random server from a temp list and checks its
                 # availability, if not available tries another one
-                server = temp_list.pop(randint(0, len(temp_list) - 1))
-                if not server[2]:  # server is offline
-                    if (isinstance(self.server_pool.exhaust, bool) and self.server_pool.exhaust) or (datetime.now() - server[1]).seconds < self.server_pool.exhaust:  # keeps server offline
+                server_state = temp_list.pop(randint(0, len(temp_list) - 1))
+                if not server_state.available:  # server is offline
+                    if (isinstance(self.server_pool.exhaust, bool) and self.server_pool.exhaust) or (datetime.now() - server_state.last_checked_time).seconds < self.server_pool.exhaust:  # keeps server offline
                         if log_enabled(NETWORK):
-                            log(NETWORK, 'server <%s> excluded from checking because it is offline', server[0])
+                            log(NETWORK, 'server <%s> excluded from checking because it is offline', server_state.server)
                         continue
                     if log_enabled(NETWORK):
-                            log(NETWORK, 'server <%s> reinserted in pool', server[0])
-                server[1] = datetime.now()
+                            log(NETWORK, 'server <%s> reinserted in pool', server_state.server)
+                server_state.last_checked_time = datetime.now()
                 if log_enabled(NETWORK):
-                    log(NETWORK, 'checking server <%s> for availability', server[0])
-                if server[0].check_availability():
+                    log(NETWORK, 'checking server <%s> for availability', server_state.server)
+                if server_state.server.check_availability():
                     # returns a random active server in the pool
-                    server[2] = True
-                    return self.servers.index(server)
+                    server_state.available = True
+                    return self.server_states.index(server_state)
                 else:
-                    server[2] = False
+                    server_state.available = False
             if not isinstance(self.server_pool.active, bool):
                 counter -= 1
         if log_enabled(ERROR):
@@ -138,35 +142,36 @@ class ServerPoolState(object):
     def find_active_server(self, starting):
         conf_pool_timeout = get_config_parameter('POOLING_LOOP_TIMEOUT')
         counter = self.server_pool.active  # can be True for "forever" or the number of cycles to try
-        if starting >= len(self.servers):
+        if starting >= len(self.server_states):
             starting = 0
 
         while counter:
             if log_enabled(NETWORK):
                 log(NETWORK, 'entering loop number <%s> for finding active server in pool <%s>', counter, self)
             index = -1
-            pool_size = len(self.servers)
+            pool_size = len(self.server_states)
             while index < pool_size - 1:
                 index += 1
                 offset = index + starting if index + starting < pool_size else index + starting - pool_size
-                if not self.servers[offset][2]:  # server is offline
-                    if (isinstance(self.server_pool.exhaust, bool) and self.server_pool.exhaust) or (datetime.now() - self.servers[offset][1]).seconds < self.server_pool.exhaust:  # keeps server offline
+                server_state = self.server_states[offset]
+                if not server_state.available:  # server is offline
+                    if (isinstance(self.server_pool.exhaust, bool) and self.server_pool.exhaust) or (datetime.now() - server_state.last_checked_time).seconds < self.server_pool.exhaust:  # keeps server offline
                         if log_enabled(NETWORK):
                             if isinstance(self.server_pool.exhaust, bool):
-                                log(NETWORK, 'server <%s> excluded from checking because is offline', self.servers[offset][0])
+                                log(NETWORK, 'server <%s> excluded from checking because is offline', server_state.server)
                             else:
-                                log(NETWORK, 'server <%s> excluded from checking because is offline for %d seconds', self.servers[offset][0], (self.server_pool.exhaust - (datetime.now() - self.servers[offset][1]).seconds))
+                                log(NETWORK, 'server <%s> excluded from checking because is offline for %d seconds', server_state.server, (self.server_pool.exhaust - (datetime.now() - server_state.last_checked_time).seconds))
                         continue
                     if log_enabled(NETWORK):
-                            log(NETWORK, 'server <%s> reinserted in pool', self.servers[offset][0])
-                self.servers[offset][1] = datetime.now()
+                            log(NETWORK, 'server <%s> reinserted in pool', server_state.server)
+                server_state.last_checked_time = datetime.now()
                 if log_enabled(NETWORK):
-                    log(NETWORK, 'checking server <%s> for availability', self.servers[offset][0])
-                if self.servers[offset][0].check_availability():
-                    self.servers[offset][2] = True
+                    log(NETWORK, 'checking server <%s> for availability', server_state.server)
+                if server_state.server.check_availability():
+                    server_state.available = True
                     return offset
                 else:
-                    self.servers[offset][2] = False  # sets server offline
+                    server_state.available = False  # sets server offline
 
             if not isinstance(self.server_pool.active, bool):
                 counter -= 1
@@ -179,7 +184,7 @@ class ServerPoolState(object):
         raise LDAPServerPoolExhaustedError('no active server available in server pool after maximum number of tries')
 
     def __len__(self):
-        return len(self.servers)
+        return len(self.server_states)
 
 
 class ServerPool(object):


### PR DESCRIPTION
Instead of constructing a list of three items to store the state of a
server in a pool, this change introduces the ServerState namedtuple.

This has the advantage that parts of the tuple can be referenced by name,
so instead of writing servers[offset][0] we can now write
server_states[offset].server.