### PR TITLE
ldap3.extend.microsoft: fix unsafe groups dn and code refactoring

### DIFF
--- a/ldap3/extend/microsoft/addMembersToGroups.py
+++ b/ldap3/extend/microsoft/addMembersToGroups.py
@@ -50,6 +50,10 @@ def ad_add_members_to_groups(connection,
     if not isinstance(groups_dn, SEQUENCE_TYPES):
         groups_dn = [groups_dn]
 
+    if connection.check_names:  # builds new lists with sanitized dn
+        members_dn = [safe_dn(member_dn) for member_dn in members_dn]
+        groups_dn = [safe_dn(group_dn) for group_dn in groups_dn]
+
     error = False
     for group in groups_dn:
         if fix:  # checks for existance of group and for already assigned members
@@ -70,7 +74,7 @@ def ad_add_members_to_groups(connection,
             existing_members = []
 
         changes = dict()
-        member_to_add = [safe_dn(element) for element in members_dn if safe_dn(element).lower() not in existing_members]
+        member_to_add = [element for element in members_dn if element.lower() not in existing_members]
         if member_to_add:
             changes['member'] = (MODIFY_ADD, member_to_add)
         if changes:

--- a/ldap3/extend/microsoft/removeMembersFromGroups.py
+++ b/ldap3/extend/microsoft/removeMembersFromGroups.py
@@ -22,6 +22,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
+
 from ...core.exceptions import LDAPInvalidDnError, LDAPOperationsErrorResult
 from ... import SEQUENCE_TYPES, MODIFY_DELETE, BASE, DEREF_NEVER
 from ...utils.dn import safe_dn
@@ -49,15 +50,8 @@ def ad_remove_members_from_groups(connection,
         groups_dn = [groups_dn]
 
     if connection.check_names:  # builds new lists with sanitized dn
-        safe_members_dn = []
-        safe_groups_dn = []
-        for member_dn in members_dn:
-            safe_members_dn.append(safe_dn(member_dn))
-        for group_dn in groups_dn:
-            safe_groups_dn.append(safe_dn(group_dn))
-
-        members_dn = safe_members_dn
-        groups_dn = safe_groups_dn
+        members_dn = [safe_dn(member_dn) for member_dn in members_dn]
+        groups_dn = [safe_dn(group_dn) for group_dn in groups_dn]
 
     error = False
 


### PR DESCRIPTION
In my previous PR(#619) i missed [ad_remove_members_from_groups ](https://github.com/cannatag/ldap3/blob/master/ldap3/extend/microsoft/removeMembersFromGroups.py) function. So this PR fixes unsafe groups/members dn in `ad_add_members_to_groups` function including `connection.check_names` logic(like it implemented in [ad_remove_members_from_groups](https://github.com/cannatag/ldap3/blob/master/ldap3/extend/microsoft/removeMembersFromGroups.py#L49)).