### PR TITLE
Fix issue #639

### DIFF
--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -324,6 +324,24 @@ except ImportError:
         return raw_value
 
 
+def format_ad_timedelta(raw_value):
+    """
+    Convert a negative filetime value to a timedelta.
+    """
+    # Active Directory stores attributes like "minPwdAge" as a negative
+    # "filetime" timestamp, which is the number of 100-nanosecond intervals that
+    # have elapsed since the 0 hour on January 1, 1601. By making the number
+    # positive, we can reuse format_ad_timestamp to get a datetime object.
+    # Afterwards, we can subtract a datetime representing 0 hour on January 1,
+    # 1601 from the returned datetime to get the timedelta.
+    try:
+        raw_value = raw_value.decode()
+    except AttributeError:
+        pass
+    raw_value = int(raw_value)
+    return format_ad_timestamp(raw_value * -1) - format_ad_timestamp(0)
+
+
 def format_time_with_0_year(raw_value):
     try:
         if raw_value.startswith(b'0000'):

--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -108,10 +108,10 @@ def format_ad_timestamp(raw_value):
     try:
         timestamp = int(raw_value)
         if timestamp < 0:  # ad timestamp cannot be negative
-            return raw_value
+            timestamp = timestamp * -1
     except Exception:
         return raw_value
-
+    
     try:
         return datetime.fromtimestamp(timestamp / 10000000.0 - 11644473600, tz=OffsetTzInfo(0, 'UTC'))  # forces true division in python 2
     except (OSError, OverflowError, ValueError):  # on Windows backwards timestamps are not allowed
@@ -334,12 +334,7 @@ def format_ad_timedelta(raw_value):
     # positive, we can reuse format_ad_timestamp to get a datetime object.
     # Afterwards, we can subtract a datetime representing 0 hour on January 1,
     # 1601 from the returned datetime to get the timedelta.
-    try:
-        raw_value = raw_value.decode()
-    except AttributeError:
-        pass
-    raw_value = int(raw_value)
-    return format_ad_timestamp(raw_value * -1) - format_ad_timestamp(0)
+    return format_ad_timestamp(raw_value) - format_ad_timestamp(0)
 
 
 def format_time_with_0_year(raw_value):

--- a/ldap3/protocol/formatters/standard.py
+++ b/ldap3/protocol/formatters/standard.py
@@ -25,10 +25,12 @@
 
 from ... import SEQUENCE_TYPES
 from .formatters import format_ad_timestamp, format_binary, format_boolean,\
-    format_integer, format_sid, format_time, format_unicode, format_uuid, format_uuid_le, format_time_with_0_year
+    format_integer, format_sid, format_time, format_unicode, format_uuid, format_uuid_le, format_time_with_0_year,\
+    format_ad_timedelta
 from .validators import validate_integer, validate_time, always_valid,\
     validate_generic_single_value, validate_boolean, validate_ad_timestamp, validate_sid,\
-    validate_uuid_le, validate_uuid, validate_zero_and_minus_one_and_positive_int, validate_guid, validate_time_with_0_year
+    validate_uuid_le, validate_uuid, validate_zero_and_minus_one_and_positive_int, validate_guid, validate_time_with_0_year,\
+    validate_ad_timedelta
 
 # for each syntax can be specified a format function and a input validation function
 
@@ -121,6 +123,9 @@ standard_formatter = {
     '1.2.840.113556.1.4.49': (format_ad_timestamp, validate_ad_timestamp),  # badPasswordTime (Microsoft)
     '1.2.840.113556.1.4.51': (format_ad_timestamp, validate_ad_timestamp),  # lastLogoff (Microsoft)
     '1.2.840.113556.1.4.52': (format_ad_timestamp, validate_ad_timestamp),  # lastLogon (Microsoft)
+    '1.2.840.113556.1.4.60': (format_ad_timedelta, validate_ad_timedelta),  # lockoutDuration (Microsoft)
+    '1.2.840.113556.1.4.74': (format_ad_timedelta, validate_ad_timedelta),  # maxPwdAge (Microsoft)
+    '1.2.840.113556.1.4.78': (format_ad_timedelta, validate_ad_timedelta),  # minPwdAge (Microsoft)
     '1.2.840.113556.1.4.96': (format_ad_timestamp, validate_zero_and_minus_one_and_positive_int),  # pwdLastSet (Microsoft, can be set to -1 only)
     '1.2.840.113556.1.4.146': (format_sid, validate_sid),  # objectSid (Microsoft)
     '1.2.840.113556.1.4.159': (format_ad_timestamp, validate_ad_timestamp),  # accountExpires (Microsoft)

--- a/ldap3/protocol/formatters/standard.py
+++ b/ldap3/protocol/formatters/standard.py
@@ -124,6 +124,7 @@ standard_formatter = {
     '1.2.840.113556.1.4.51': (format_ad_timestamp, validate_ad_timestamp),  # lastLogoff (Microsoft)
     '1.2.840.113556.1.4.52': (format_ad_timestamp, validate_ad_timestamp),  # lastLogon (Microsoft)
     '1.2.840.113556.1.4.60': (format_ad_timedelta, validate_ad_timedelta),  # lockoutDuration (Microsoft)
+    '1.2.840.113556.1.4.61': (format_ad_timedelta, validate_ad_timedelta),  # lockOutObservationWindow (Microsoft)
     '1.2.840.113556.1.4.74': (format_ad_timedelta, validate_ad_timedelta),  # maxPwdAge (Microsoft)
     '1.2.840.113556.1.4.78': (format_ad_timedelta, validate_ad_timedelta),  # minPwdAge (Microsoft)
     '1.2.840.113556.1.4.96': (format_ad_timestamp, validate_zero_and_minus_one_and_positive_int),  # pwdLastSet (Microsoft, can be set to -1 only)


### PR DESCRIPTION
The issue #639 seems to be fixed with this little patch.

I think @may-day have the correct idea, but since the `format_ad_timestamp` uses a bytes as argument, the negative number should be corrected in this function instead of `format_ad_timedelta`.

Successfully tested with python 3.7.0 and python 2.7.12 from Ubuntu and an LDAP server which is running Windows 2012 R2.