### PR TITLE
utils: fix safe_dn function

### DIFF
--- a/ldap3/utils/dn.py
+++ b/ldap3/utils/dn.py
@@ -319,7 +319,7 @@ def safe_dn(dn, decompose=False, reverse=False):
 
     if dn.startswith('<GUID=') and dn.endswith('>'):  # Active Directory allows looking up objects by putting its GUID in a specially-formatted DN (e.g. '<GUID=7b95f0d5-a3ed-486c-919c-077b8c9731f2>')
         escaped_dn = dn
-    elif '@' not in dn and '\\' not in dn:  # active directory UPN (User Principal Name) consist of an account, the at sign (@) and a domain, or the domain level logn name domain\username
+    elif '@' not in dn:  # active directory UPN (User Principal Name) consist of an account, the at sign (@) and a domain, or the domain level logn name domain\username
         for component in parse_dn(dn, escape=True):
             if decompose:
                 escaped_dn.append((component[0], component[1], component[2]))


### PR DESCRIPTION
Hi!

if this check `and '\\' not in dn` [#L322](https://github.com/cannatag/ldap3/blob/master/ldap3/utils/dn.py#L322) is `False` this 
interpreted like `"` characters are escaped, but if we have DN: `CN=Some cn with " quotes ,OU=Containre \\"Name\\",DC=Company,DC=com` it will not be escaped and `elif` statement returns `False`.