### PR TITLE
add json converter for timedelta

### DIFF
--- a/ldap3/utils/conv.py
+++ b/ldap3/utils/conv.py
@@ -193,6 +193,9 @@ def format_json(obj):
     if isinstance(obj, int):
         return obj
 
+    if isinstance(obj, datetime.timedelta):
+        return str(obj)
+
     if str is bytes:  # Python 2
         if isinstance(obj, long):  # long exists only in python2
             return obj


### PR DESCRIPTION
The json encoder doesn't like timedelta objects that were added for some AD properties in 2.5.2, encoding them as a string like datetime objects fixes this.