### PR TITLE
Extensive unit tests for parse_dn with escaped attribute values

### DIFF
--- a/ldap3/utils/dn.py
+++ b/ldap3/utils/dn.py
@@ -272,6 +272,16 @@ def _escape_attribute_value(attribute_value):
 
 
 def parse_dn(dn, escape=False, strip=False):
+    """
+    Parses a DN into syntactic components
+    :param dn:
+    :param escape:
+    :param strip:
+    :return:
+    a list of tripels representing `attributeTypeAndValue` elements
+    containing `attributeType`, `attributeValue` and the following separator (`COMMA` or `PLUS`) if given, else an empty `str`.
+    in their original representation, still containing escapes or encoded as hex.
+    """
     rdns = []
     avas = []
     while dn:

--- a/test/testDnParsing.py
+++ b/test/testDnParsing.py
@@ -139,8 +139,8 @@ class Test(unittest.TestCase):
                         dn = r'cn={0}{1}ou={0}'.format(attributeValue, separator)
                         expected = [('cn', attributeValue, separator), ('ou', attributeValue, '')]
 
-                    with self.subTest(pair=onepair, separator=separator, input=dn):
-                        self.test_parse_dn(
+                    with self.subTest(pair=onepair, separator=separator, mode=mode, input=dn):
+                        self._test_parse_dn(
                             dn,
                             expected
                         )
@@ -168,7 +168,7 @@ class Test(unittest.TestCase):
         variants = set(self.combine_strings(['a', 'b'], []))
         self.assertEqual(len(variants), 0)
 
-    def test_parse_dn(self, input, expected):
+    def _test_parse_dn(self, input, expected):
         parsed = p(input)
         self.assertEqual(parsed, expected)
 

--- a/test/testDnParsing.py
+++ b/test/testDnParsing.py
@@ -109,3 +109,77 @@ class Test(unittest.TestCase):
         self.assertEqual(parsed[0], ('cn', 'us\\+er1', '+'))
         self.assertEqual(parsed[1], ('sn', 'su\\,rname1', ','))
         self.assertEqual(parsed[2], ('o', 'users', ''))
+
+    def pair_generator(self):
+        # escaped = DQUOTE / PLUS / COMMA / SEMI / LANGLE / RANGLE
+        escaped = ['"', '+', ',', ';', '<', '>']
+        # special = escaped / SPACE / SHARP / EQUALS
+        special = escaped + [' ', '#', '=']
+        ESC = ['\\']
+        # hexpair = HEX HEX
+        hexpairs = ['00', '99', 'aa', 'AA', 'ff', 'FF', 'aF', 'Af']
+        # pair = ESC ( ESC / special / hexpair )
+        pair = self.combine_strings(ESC, ESC + special + hexpairs)
+        return pair
+
+    def test_parse_dn_pair(self):
+        for onepair in self.pair_generator():
+            for attributeValue, mode in [
+                (onepair, "alone"),
+                ("a" + onepair + "b", "between"),
+                ("a" + onepair, "after"),
+                (onepair + "b", "before")
+            ]:
+                for separator in [None, '+', ',']:
+
+                    if not separator:
+                        dn = r'cn={0}'.format(attributeValue)
+                        expected = [('cn', attributeValue, '')]
+                    else:
+                        dn = r'cn={0}{1}ou={0}'.format(attributeValue, separator)
+                        expected = [('cn', attributeValue, separator), ('ou', attributeValue, '')]
+
+                    with self.subTest(pair=onepair, separator=separator, input=dn):
+                        self.test_parse_dn(
+                            dn,
+                            expected
+                        )
+
+    def combine_strings(self, *args):
+        if len(args) == 0: raise Exception("Invalid parameter")
+        if len(args) == 1:
+            for variant in args[0]:
+                yield variant
+        else:
+            for head in args[0]:
+                for tail in self.combine_strings(*args[1:]):
+                    variant = head + tail
+                    yield variant
+
+    def test_combine_strings(self):
+        variants = set(self.combine_strings(['a', 'b'], ['x', 'y']))
+        self.assertEqual(variants, {'ax', 'ay', 'bx', 'by'})
+
+    def test_combine_strings_empty1(self):
+        variants = set(self.combine_strings([], ['x', 'y']))
+        self.assertEqual(len(variants), 0)
+
+    def test_combine_strings_empty2(self):
+        variants = set(self.combine_strings(['a', 'b'], []))
+        self.assertEqual(len(variants), 0)
+
+    def test_parse_dn(self, input, expected):
+        parsed = p(input)
+        self.assertEqual(parsed, expected)
+
+    def test_unit_test_deep_equality(self):
+        self.assertEqual([], [])
+        self.assertNotEqual([], [()])
+        self.assertEqual([()], [()])
+        self.assertNotEqual([()], [(), ()])
+        self.assertNotEqual([()], [('b')])
+        self.assertEqual([('a')], [('a')])
+        self.assertNotEqual([('a')], [('b')])
+        self.assertEqual([('a', 'b', 'x'), ('a', 'b', 'x')], [('a', 'b', 'x'), ('a', 'b', 'x')])
+        self.assertNotEqual([('a', 'b', 'x'), ('a', 'b', 'x')], [('a', 'b', 'x'), ('a', 'b', 'y')])
+        self.assertNotEqual([('1')], [(1)])


### PR DESCRIPTION
For #667

Parametrized tests probably don't work on python2.
`test_unit_test_deep_equality` might be disposable -- the repeated asserts made me doubt whether deep comparison of results is possible.

Currently still fails for trailing double escapes (pair = ESC ESC) when COMMA or PLUS is present:
e.g. `cn=\\,ou=\\` 

```
SubTest error: Traceback (most recent call last):
  File "C:\Users\phi1010\Anaconda3\envs\ldap3\lib\unittest\case.py", line 59, in testPartExecutor
    yield
  File "C:\Users\phi1010\Anaconda3\envs\ldap3\lib\unittest\case.py", line 533, in subTest
    yield
  File "C:\Users\phi1010\PycharmProjects\ldap3\test\testDnParsing.py", line 145, in test_parse_dn_pair
    expected
  File "C:\Users\phi1010\PycharmProjects\ldap3\test\testDnParsing.py", line 172, in test_parse_dn
    parsed = p(input)
  File "C:\Users\phi1010\PycharmProjects\ldap3\ldap3\utils\dn.py", line 302, in parse_dn
    if not _validate_attribute_value(attribute_value):
  File "C:\Users\phi1010\PycharmProjects\ldap3\ldap3\utils\dn.py", line 192, in _validate_attribute_value
    raise LDAPInvalidDnError('special character ' + c + ' must be escaped')
ldap3.core.exceptions.LDAPInvalidDnError: special character , must be escaped


One or more subtests failed
Failed subtests list:
(pair='\\\\', separator='+', input='cn=\\\\+ou=\\\\')
(pair='\\\\', separator=',', input='cn=\\\\,ou=\\\\')
(pair='\\\\', separator='+', input='cn=a\\\\+ou=a\\\\')
(pair='\\\\', separator=',', input='cn=a\\\\,ou=a\\\\')
```
