### PR TITLE
Handle the minimum value that can be stored in an Int64 in format_ad_timedelta

### DIFF
--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -338,10 +338,16 @@ def format_ad_timedelta(raw_value):
     """
     # Active Directory stores attributes like "minPwdAge" as a negative
     # "filetime" timestamp, which is the number of 100-nanosecond intervals that
-    # have elapsed since the 0 hour on January 1, 1601. By making the number
-    # positive, we can reuse format_ad_timestamp to get a datetime object.
-    # Afterwards, we can subtract a datetime representing 0 hour on January 1,
-    # 1601 from the returned datetime to get the timedelta.
+    # have elapsed since the 0 hour on January 1, 1601.
+    #
+    # Handle the minimum value that can be stored in a 64 bit signed integer.
+    # See https://docs.microsoft.com/en-us/dotnet/api/system.int64.minvalue
+    # In attributes like "maxPwdAge", this signifies never.
+    if raw_value == b'-9223372036854775808':
+        return timedelta.max
+    # We can reuse format_ad_timestamp to get a datetime object from the
+    # timestamp. Afterwards, we can subtract a datetime representing 0 hour on
+    # January 1, 1601 from the returned datetime to get the timedelta.
     return format_ad_timestamp(raw_value) - format_ad_timestamp(0)
 
 


### PR DESCRIPTION
Active Directory uses the minimum value of an Int64 to signify "never" in the "maxPwdAge" LDAP attribute on a domain. When this value is handled in `format_ad_timedelta` in the current code, an exception is raised. This PR fixes that issue.