### PR TITLE
EntryState: `entry_raw_attributes` is populated instead of `raw_attributes`

### DIFF
--- a/ldap3/abstract/cursor.py
+++ b/ldap3/abstract/cursor.py
@@ -311,7 +311,7 @@ class Cursor(object):
 
         entry = self.entry_class(response['dn'], self)  # define an Entry (writable or readonly), as specified in the cursor definition
         entry._state.attributes = self._get_attributes(response, self.definition._attributes, entry)
-        entry._state.entry_raw_attributes = deepcopy(response['raw_attributes'])
+        entry._state.raw_attributes = deepcopy(response['raw_attributes'])
 
         entry._state.response = response
         entry._state.read_time = datetime.now()

--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -107,6 +107,10 @@ class EntryState(object):
                         self.status = STATUS_MANDATORY_MISSING
                         break
 
+    @property
+    def entry_raw_attributes(self):
+        return self.raw_attributes
+
 
 class EntryBase(object):
     """The Entry object contains a single LDAP entry.

--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -273,7 +273,7 @@ class EntryBase(object):
 
     @property
     def entry_raw_attributes(self):
-        return self._state.entry_raw_attributes
+        return self._state.raw_attributes
 
     def entry_raw_attribute(self, name):
         """
@@ -281,7 +281,7 @@ class EntryBase(object):
         :param name: name of the attribute
         :return: raw (unencoded) value of the attribute, None if attribute is not found
         """
-        return self._state.entry_raw_attributes[name] if name in self._state.entry_raw_attributes else None
+        return self._state.raw_attributes[name] if name in self._state.raw_attributes else None
 
     @property
     def entry_mandatory_attributes(self):


### PR DESCRIPTION
According to the constructor of `EntryState` the variable name should be
`raw_attributes` whereas the rest of the code uses `entry_raw_attributes`
for populating the dictionary resulting in an empty `raw_attributes` dict.
The `Entry` class uses a property `entry_raw_attributes` for providing access.

For backwards compatibility with possibly external software using `EntryState` the previous name is provided as property.