### PR TITLE
Test on Python 3.7 and PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
+dist: xenial
 python:
   - "2.6"
   - "2.7"
   - "3.6"
+  - "3.7"
   # - "nightly"
   #- "pypy"
-  # - "pypy3"
+  - "pypy3"
 sudo: false
 env:
   global:


### PR DESCRIPTION
`dist: xenial` is required for Python 3.7.