### PR TITLE
Fix pickling of entry and attribute

### DIFF
--- a/ldap3/abstract/attribute.py
+++ b/ldap3/abstract/attribute.py
@@ -83,6 +83,11 @@ class Attribute(object):
     def __getitem__(self, item):
         return self.values[item]
 
+    def __getstate__(self):
+        cpy = dict(self.__dict__)
+        cpy['cursor'] = None
+        return cpy
+
     def __eq__(self, other):
         try:
             if self.value == other:

--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -86,6 +86,11 @@ class EntryState(object):
     def __str__(self):
         return self.__repr__()
 
+    def __getstate__(self):
+        cpy = dict(self.__dict__)
+        cpy['cursor'] = None
+        return cpy
+
     def set_status(self, status):
         conf_ignored_mandatory_attributes_in_object_def = [v.lower() for v in get_config_parameter('IGNORED_MANDATORY_ATTRIBUTES_IN_OBJECT_DEF')]
         if status not in STATUSES:

--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -36,7 +36,7 @@ from .. import STRING_TYPES, SEQUENCE_TYPES, MODIFY_ADD, MODIFY_REPLACE
 from .attribute import WritableAttribute
 from .objectDef import ObjectDef
 from .attrDef import AttrDef
-from ..core.exceptions import LDAPKeyError, LDAPCursorError
+from ..core.exceptions import LDAPKeyError, LDAPCursorError, LDAPCursorAttributeError
 from ..utils.conv import check_json_dict, format_json, prepare_for_stream
 from ..protocol.rfc2849 import operation_to_ldif, add_ldif_header
 from ..utils.dn import safe_dn, safe_rdn, to_dn
@@ -193,12 +193,12 @@ class EntryBase(object):
                 error_message = 'attribute \'%s\' not found' % item
                 if log_enabled(ERROR):
                     log(ERROR, '%s for <%s>', error_message, self)
-                raise LDAPCursorError(error_message)
+                raise LDAPCursorAttributeError(error_message)
             return self._state.attributes[attr]
         error_message = 'attribute name must be a string'
         if log_enabled(ERROR):
             log(ERROR, '%s for <%s>', error_message, self)
-        raise LDAPCursorError(error_message)
+        raise LDAPCursorAttributeError(error_message)
 
     def __setattr__(self, item, value):
         if item == '_state':
@@ -207,12 +207,12 @@ class EntryBase(object):
             error_message = 'attribute \'%s\' is read only' % item
             if log_enabled(ERROR):
                 log(ERROR, '%s for <%s>', error_message, self)
-            raise LDAPCursorError(error_message)
+            raise LDAPCursorAttributeError(error_message)
         else:
             error_message = 'entry is read only, cannot add \'%s\'' % item
             if log_enabled(ERROR):
                 log(ERROR, '%s for <%s>', error_message, self)
-            raise LDAPCursorError(error_message)
+            raise LDAPCursorAttributeError(error_message)
 
     def __getitem__(self, item):
         if isinstance(item, STRING_TYPES):
@@ -473,7 +473,7 @@ class WritableEntry(EntryBase):
                 error_message = 'attribute \'%s\' not defined' % item
                 if log_enabled(ERROR):
                     log(ERROR, '%s for <%s>', error_message, self)
-                raise LDAPCursorError(error_message)
+                raise LDAPCursorAttributeError(error_message)
 
     def __getattr__(self, item):
         if isinstance(item, STRING_TYPES):
@@ -493,12 +493,12 @@ class WritableEntry(EntryBase):
             error_message = 'attribute \'%s\' not defined' % item
             if log_enabled(ERROR):
                 log(ERROR, '%s for <%s>', error_message, self)
-            raise LDAPCursorError(error_message)
+            raise LDAPCursorAttributeError(error_message)
         else:
             error_message = 'attribute name must be a string'
             if log_enabled(ERROR):
                 log(ERROR, '%s for <%s>', error_message, self)
-            raise LDAPCursorError(error_message)
+            raise LDAPCursorAttributeError(error_message)
 
     @property
     def entry_virtual_attributes(self):

--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -125,7 +125,7 @@ class EntryBase(object):
     """
 
     def __init__(self, dn, cursor):
-        self.__dict__['_state'] = EntryState(dn, cursor)
+        self._state = EntryState(dn, cursor)
 
     def __repr__(self):
         if self.__dict__ and self.entry_dn is not None:
@@ -157,7 +157,7 @@ class EntryBase(object):
     def __getattr__(self, item):
         if isinstance(item, STRING_TYPES):
             if item == '_state':
-                return self.__dict__['_state']
+                return object.__getattr__(self, item)
             item = ''.join(item.split()).lower()
             attr_found = None
             for attr in self._state.attributes.keys():
@@ -201,7 +201,9 @@ class EntryBase(object):
         raise LDAPCursorError(error_message)
 
     def __setattr__(self, item, value):
-        if item in self._state.attributes:
+        if item == '_state':
+            object.__setattr__(self, item, value)
+        elif item in self._state.attributes:
             error_message = 'attribute \'%s\' is read only' % item
             if log_enabled(ERROR):
                 log(ERROR, '%s for <%s>', error_message, self)

--- a/ldap3/core/exceptions.py
+++ b/ldap3/core/exceptions.py
@@ -377,6 +377,10 @@ class LDAPCursorError(LDAPExceptionError):
     pass
 
 
+class LDAPCursorAttributeError(LDAPCursorError, AttributeError):
+    pass
+
+
 class LDAPObjectDereferenceError(LDAPExceptionError):
     pass
 


### PR DESCRIPTION
Entry and Attributes are not pickable because they all have indirect references to the Connection object holding a `threading.RLock`. With this patch the pickled representation of the objects is reduced by its cursors holding a reference to the Connection.

This merge request also fixes a violation of ``__getattr__`` and ``__setattr`` interfaces

This merge request is motivated by following issue: cfelder/ldap3-orm#5
