### PR TITLE
allowing special AD security identifier (SID) in DN

### DIFF
--- a/ldap3/utils/dn.py
+++ b/ldap3/utils/dn.py
@@ -347,6 +347,8 @@ def safe_dn(dn, decompose=False, reverse=False):
         escaped_dn = dn
     elif dn.startswith('<WKGUID=') and dn.endswith('>'):  # Active Directory allows Binding to Well-Known Objects Using WKGUID in a specially-formatted DN (e.g. <WKGUID=a9d1ca15768811d1aded00c04fd8d5cd,dc=Fabrikam,dc=com>)
         escaped_dn = dn
+    elif dn.startswith('<SID=') and dn.endswith('>'):  # Active Directory allows looking up objects by putting its security identifier (SID) in a specially-formatted DN (e.g. '<SID=S-#-#-##-##########-##########-##########-######>')
+        escaped_dn = dn
     elif '@' not in dn:  # active directory UPN (User Principal Name) consist of an account, the at sign (@) and a domain, or the domain level logn name domain\username
         for component in parse_dn(dn, escape=True):
             if decompose:


### PR DESCRIPTION
@cannatag I have a use case for using ldap3 to lookup the DN of an object when all I know is the security identifier (SID). I've tested this and it works well for me. Hoping it can be merged in and make the next release so I don't have to maintain a fork of ldap3 for my app.

Let me know if you have any questions.