### PR TITLE
Added support for source specifications in LDAP connections

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -65,11 +65,13 @@ from .usage import ConnectionUsage
 from .tls import Tls
 from .exceptions import LDAPUnknownStrategyError, LDAPBindError, LDAPUnknownAuthenticationMethodError, \
     LDAPSASLMechanismNotSupportedError, LDAPObjectClassError, LDAPConnectionIsReadOnlyError, LDAPChangeError, LDAPExceptionError, \
-    LDAPObjectError, LDAPSocketReceiveError, LDAPAttributeError, LDAPInvalidValueError, LDAPConfigurationError
+    LDAPObjectError, LDAPSocketReceiveError, LDAPAttributeError, LDAPInvalidValueError, LDAPConfigurationError, \
+    LDAPInvalidPortError
 
 from ..utils.conv import escape_bytes, prepare_for_stream, check_json_dict, format_json, to_unicode
 from ..utils.log import log, log_enabled, ERROR, BASIC, PROTOCOL, EXTENDED, get_library_log_hide_sensitive_data
 from ..utils.dn import safe_dn
+from ..utils.port_validators import check_port_and_port_list
 
 
 SASL_AVAILABLE_MECHANISMS = [EXTERNAL,
@@ -169,8 +171,15 @@ class Connection(object):
     :param use_referral_cache: keep referral connections open and reuse them
     :type use_referral_cache: bool
     :param auto_escape: automatic escaping of filter values
+    :type auto_escape: bool
     :param auto_encode: automatic encoding of attribute values
-    :type use_referral_cache: bool
+    :type auto_encode: bool
+    :param source_address: the ip address or hostname to use as the source when opening the connection to the server
+    :type source_address: str
+    :param source_port: the source port to use when opening the connection to the server. Cannot be specified with source_port_list
+    :type source_port: int
+    :param source_port_list: a list of source ports to choose from when opening the connection to the server. Cannot be specified with source_port
+    :type source_port_list: list
     """
 
     def __init__(self,
@@ -200,7 +209,10 @@ class Connection(object):
                  use_referral_cache=False,
                  auto_escape=True,
                  auto_encode=True,
-                 pool_keepalive=None):
+                 pool_keepalive=None,
+                 source_address=None,
+                 source_port=None,
+                 source_port_list=None):
 
         conf_default_pool_name = get_config_parameter('DEFAULT_THREADED_POOL_NAME')
         self.connection_lock = RLock()  # re-entrant lock to ensure that operations in the Connection object are executed atomically in the same thread
@@ -273,6 +285,23 @@ class Connection(object):
             self.use_referral_cache = use_referral_cache
             self.auto_escape = auto_escape
             self.auto_encode = auto_encode
+
+            port_err = check_port_and_port_list(source_port, source_port_list)
+            if port_err:
+                if log_enabled(ERROR):
+                    log(ERROR, port_err)
+                raise LDAPInvalidPortError(port_err)
+            # using an empty string to bind a socket means "use the default as if this wasn't provided" because socket
+            # binding requires that you pass something for the ip if you want to pass a specific port
+            self.source_address = source_address if source_address is not None else ''
+            # using 0 as the source port to bind a socket means "use the default behavior of picking a random port from
+            # all ports as if this wasn't provided" because socket binding requires that you pass something for the port
+            # if you want to pass a specific ip
+            self.source_port_list = [0]
+            if source_port is not None:
+                self.source_port_list = [source_port]
+            elif source_port_list is not None:
+                self.source_port_list = source_port_list[:]
 
             if isinstance(server, STRING_TYPES):
                 server = Server(server)

--- a/ldap3/core/server.py
+++ b/ldap3/core/server.py
@@ -33,8 +33,9 @@ from ..protocol.formatters.standard import format_attribute_values
 from ..protocol.rfc4511 import LDAP_MAX_INT
 from ..protocol.rfc4512 import SchemaInfo, DsaInfo
 from .tls import Tls
-from ..utils.log import log, log_enabled, ERROR, BASIC, PROTOCOL
+from ..utils.log import log, log_enabled, ERROR, BASIC, PROTOCOL, NETWORK
 from ..utils.conv import to_unicode
+from ..utils.port_validators import check_port, check_port_and_port_list
 
 try:
     from urllib.parse import unquote  # Python 3
@@ -147,17 +148,12 @@ class Server(object):
             elif use_ssl and not port:
                 port = 636
 
-            if isinstance(port, int):
-                if port in range(0, 65535):
-                    self.port = port
-                else:
-                    if log_enabled(ERROR):
-                        log(ERROR, 'port <%s> must be in range from 0 to 65535', port)
-                    raise LDAPInvalidPortError('port must in range from 0 to 65535')
-            else:
+            port_err = check_port(port)
+            if port_err:
                 if log_enabled(ERROR):
-                    log(ERROR, 'port <%s> must be an integer', port)
-                raise LDAPInvalidPortError('port must be an integer')
+                    log(ERROR, port_err)
+                raise LDAPInvalidPortError(port_err)
+            self.port = port
 
         if allowed_referral_hosts is None:  # defaults to any server with authentication
             allowed_referral_hosts = [('*', True)]
@@ -279,12 +275,36 @@ class Server(object):
             address[5] = None
             address[6] = None
 
-    def check_availability(self):
+    def check_availability(self, source_address=None, source_port=None, source_port_list=None):
         """
-        Tries to open, connect and close a socket to specified address
-        and port to check availability. Timeout in seconds is specified in CHECK_AVAILABITY_TIMEOUT if not specified in
-        the Server object
+        Tries to open, connect and close a socket to specified address and port to check availability.
+        Timeout in seconds is specified in CHECK_AVAILABITY_TIMEOUT if not specified in
+        the Server object.
+        If specified, use a specific address, port, or list of possible ports, when attempting to check availability.
+        NOTE: This will only consider multiple ports from the source port list if the first ones we try to bind to are
+              already in use. This will not attempt using different ports in the list if the server is unavailable,
+              as that could result in the runtime of check_availability significantly exceeding the connection timeout.
         """
+        source_port_err = check_port_and_port_list(source_port, source_port_list)
+        if source_port_err:
+            if log_enabled(ERROR):
+                log(ERROR, source_port_err)
+            raise LDAPInvalidPortError(source_port_err)
+
+        # using an empty string to bind a socket means "use the default as if this wasn't provided" because socket
+        # binding requires that you pass something for the ip if you want to pass a specific port
+        bind_address = source_address if source_address is not None else ''
+        # using 0 as the source port to bind a socket means "use the default behavior of picking a random port from
+        # all ports as if this wasn't provided" because socket binding requires that you pass something for the port
+        # if you want to pass a specific ip
+        candidate_bind_ports = [0]
+
+        # if we have either a source port or source port list, convert that into our candidate list
+        if source_port is not None:
+            candidate_bind_ports = [source_port]
+        elif source_port_list is not None:
+            candidate_bind_ports = source_port_list[:]
+
         conf_availability_timeout = get_config_parameter('CHECK_AVAILABILITY_TIMEOUT')
         available = False
         self.reset_availability()
@@ -292,6 +312,33 @@ class Server(object):
             available = True
             try:
                 temp_socket = socket.socket(*address[:3])
+
+                # Go through our candidate bind ports and try to bind our socket to our source address with them.
+                # if no source address or ports were specified, this will have the same success/fail result as if we
+                # tried to connect to the remote server without binding locally first.
+                # This is actually a little bit better, as it lets us distinguish the case of "issue binding the socket
+                # locally" from "remote server is unavailable" with more clarity, though this will only really be an
+                # issue when no source address/port is specified if the system checking server availability is running
+                # as a very unprivileged user.
+                last_bind_exc = None
+                socket_bind_succeeded = False
+                for bind_port in candidate_bind_ports:
+                    try:
+                        temp_socket.bind((bind_address, bind_port))
+                        socket_bind_succeeded = True
+                        break
+                    except Exception as bind_ex:
+                        last_bind_exc = bind_ex
+                        if log_enabled(NETWORK):
+                            log(NETWORK, 'Unable to bind to local address <%s> with source port <%s> due to <%s>',
+                                bind_address, bind_port, bind_ex)
+                if not socket_bind_succeeded:
+                    if log_enabled(ERROR):
+                        log(ERROR, 'Unable to locally bind to local address <%s> with any of the source ports <%s> due to <%s>',
+                            bind_address, candidate_bind_ports, last_bind_exc)
+                    raise LDAPSocketOpenError('Unable to bind socket locally to address {} with any of the source ports {} due to {}'
+                                              .format(bind_address, candidate_bind_ports, last_bind_exc))
+
                 if self.connect_timeout:
                     temp_socket.settimeout(self.connect_timeout)
                 else:

--- a/ldap3/utils/port_validators.py
+++ b/ldap3/utils/port_validators.py
@@ -1,0 +1,37 @@
+""" Some helper functions for validation of ports and lists of ports. """
+
+
+def check_port(port):
+    """ Check if a port is valid. Return an error message indicating what is invalid if something isn't valid. """
+    if isinstance(port, int):
+        if port not in range(0, 65535):
+            return 'Source port must in range from 0 to 65535'
+    else:
+        return 'Source port must be an integer'
+    return None
+
+
+def check_port_and_port_list(port, port_list):
+    """ Take in a port and a port list and check that at most one is non-null. Additionally check that if either
+    is non-null, it is valid.
+    Return an error message indicating what is invalid if something isn't valid.
+    """
+    if port is not None and port_list is not None:
+        return'Cannot specify both a source port and a source port list'
+    elif port is not None:
+        if isinstance(port, int):
+            if port not in range(0, 65535):
+                return 'Source port must in range from 0 to 65535'
+        else:
+            return 'Source port must be an integer'
+    elif port_list is not None:
+        try:
+            _ = iter(port_list)
+        except TypeError:
+            return 'Source port list must be an iterable {}'.format(port_list)
+
+        for candidate_port in port_list:
+            err = check_port(candidate_port)
+            if err:
+                return err
+    return None


### PR DESCRIPTION
Added support for specifying a source address and source port or source port list when opening an LDAP connection.

In many simple environments, just opening a connection to a remote server at some destination address
and port is all you need.
However, sometimes you're working an environment with multiple network partitions which aren't mutually
routable. Or you're dealing with a firewall that only allows connections through if they originate from
a specific source address or address range, and you're on a machine with multiple identities from a
networking perspective.
Alternatively, you may have multiple network identities, and you're doing mutual TLS so you want to make
sure you pick the correct one. Or you just want to control source network identity at the application
level, rather than having it be controlled via ip tables or network switch configurations. Maybe an
application has a designated range of local ports that it owns, and you want to confine it to that
range within the application rather than by using a container.

Regardless of the specific reason, there's a number of use cases for specifying a source ip/hostname to
try to use when binding the socket for a connection, as well as for specifying a source port/port list
for binding the socket locally.
This change adds support for specifying such a source address, a source port, or source port list.

The idea with this change is that source address/port are attributes of the connection, rather than the
server definition. However, to faciliate checking server availability (which is done via the server
object) with this functionality, a source address, source port, and source port list can be specified
when checking server availability as well via optional arguments.