### PR TITLE
Remove Python 2,.6 from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.6"
   # - "nightly"


### PR DESCRIPTION
Python 2.6 no longer made available

https://travis-ci.org/cannatag/ldap3/jobs/588144759

```
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-2.6.tar.bz2
0.16s$ curl -sSf -o python-2.6.tar.bz2 ${archive_url}
curl: (22) The requested URL returned error: 404 Not Found
Unable to download 2.6 archive. The archive may not exist. Please consider a different version.
```