### PR TITLE
If there are a Operational Attribute, the operation attr.virtual return error

### DIFF
--- a/ldap3/abstract/entry.py
+++ b/ldap3/abstract/entry.py
@@ -627,7 +627,7 @@ class WritableEntry(EntryBase):
                                 self._state.origin.__dict__.clear()
                                 self._state.origin.__dict__['_state'] = temp_entry._state
                                 for attr in self:  # returns the whole attribute object
-                                    if not attr.virtual:
+                                    if not hasattr(attr,'virtual'):
                                         self._state.origin.__dict__[attr.key] = self._state.origin._state.attributes[attr.key]
                                 self._state.origin._state.read_time = self.entry_read_time
                     else:


### PR DESCRIPTION
If there are a customized attribute with ';' character, it is considered a Operational Attribute, and the attr.virtual operation return error. Using hasattr(attr,'virtual') there is no error