### PR TITLE
Introduce threading.Event to replace loop checking in async strategy

### DIFF
--- a/ldap3/strategy/asynchronous.py
+++ b/ldap3/strategy/asynchronous.py
@@ -23,7 +23,7 @@
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
 
-from threading import Thread, Lock
+from threading import Thread, Lock, Event
 import socket
 
 from .. import get_config_parameter
@@ -124,6 +124,8 @@ class AsyncStrategy(BaseStrategy):
                                 self.connection.strategy._responses[message_id] = [dict_response]
                             if dict_response['type'] not in ['searchResEntry', 'searchResRef', 'intermediateResponse']:
                                 self.connection.strategy._responses[message_id].append(RESPONSE_COMPLETE)
+                                self.connection.strategy.set_event_for_message(message_id)
+
                         if self.connection.strategy.can_stream:  # for AsyncStreamStrategy, used for PersistentSearch
                             self.connection.strategy.accumulate_stream(message_id, dict_response)
                         unprocessed = unprocessed[length:]
@@ -149,6 +151,8 @@ class AsyncStrategy(BaseStrategy):
         self.can_stream = False
         self.receiver = None
         self.async_lock = Lock()
+        self.event_lock = Lock()
+        self._events = {}
 
     def open(self, reset_usage=True, read_server_info=True):
         """
@@ -173,6 +177,26 @@ class AsyncStrategy(BaseStrategy):
         with self.connection.connection_lock:
             BaseStrategy.close(self)
 
+    def _add_event_for_message(self, message_id):
+        with self.event_lock:
+            # Should have the check here because the receiver thread may has created it
+            if message_id not in self._events:
+                self._events[message_id] = Event()
+
+    def set_event_for_message(self, message_id):
+        with self.event_lock:
+            # The receiver thread may receive the response before the sender set the event for the message_id,
+            # so we have to check if the event exists
+            if message_id not in self._events:
+                self._events[message_id] = Event()
+            self._events[message_id].set()
+
+    def _get_event_for_message(self, message_id):
+        with self.event_lock:
+            if message_id not in self._events:
+                raise RuntimeError('Event for message[{}] should have been created before accessing'.format(message_id))
+            return self._events[message_id]
+
     def post_send_search(self, message_id):
         """
         Clears connection.response and returns messageId
@@ -180,6 +204,7 @@ class AsyncStrategy(BaseStrategy):
         self.connection.response = None
         self.connection.request = None
         self.connection.result = None
+        self._add_event_for_message(message_id)
         return message_id
 
     def post_send_single_response(self, message_id):
@@ -189,6 +214,7 @@ class AsyncStrategy(BaseStrategy):
         self.connection.response = None
         self.connection.request = None
         self.connection.result = None
+        self._add_event_for_message(message_id)
         return message_id
 
     def _start_listen(self):
@@ -201,15 +227,21 @@ class AsyncStrategy(BaseStrategy):
             self.receiver.daemon = True
             self.receiver.start()
 
-    def _get_response(self, message_id):
+    def _get_response(self, message_id, timeout):
         """
         Performs the capture of LDAP response for this strategy
-        Checks lock to avoid race condition with receiver thread
+        The response is only complete after the event been set
         """
-        with self.async_lock:
-            responses = self._responses.pop(message_id) if message_id in self._responses and self._responses[message_id][-1] == RESPONSE_COMPLETE else None
+        event = self._get_event_for_message(message_id)
+        flag = event.wait(timeout)
+        if not flag:
+            # timeout
+            return None
 
-        return responses
+        # In this stage we could ensure the response is already there
+        self._events.pop(message_id)
+        with self.async_lock:
+            return self._responses.pop(message_id)
 
     def receiving(self):
         raise NotImplementedError

--- a/ldap3/strategy/base.py
+++ b/ldap3/strategy/base.py
@@ -313,61 +313,54 @@ class BaseStrategy(object):
         Responses without result is stored in connection.response
         A tuple (responses, result) is returned
         """
-        conf_sleep_interval = get_config_parameter('RESPONSE_SLEEPTIME')
         if timeout is None:
             timeout = get_config_parameter('RESPONSE_WAITING_TIMEOUT')
         response = None
         result = None
         request = None
         if self._outstanding and message_id in self._outstanding:
-            while timeout >= 0:  # waiting for completed message to appear in responses
-                responses = self._get_response(message_id)
-                if not responses:
-                    sleep(conf_sleep_interval)
-                    timeout -= conf_sleep_interval
-                    continue
+            responses = self._get_response(message_id, timeout)
 
-                if responses == SESSION_TERMINATED_BY_SERVER:
-                    try:  # try to close the session but don't raise any error if server has already closed the session
-                        self.close()
-                    except (socket.error, LDAPExceptionError):
-                        pass
-                    self.connection.last_error = 'session terminated by server'
-                    if log_enabled(ERROR):
-                        log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
-                    raise LDAPSessionTerminatedByServerError(self.connection.last_error)
-                elif responses == TRANSACTION_ERROR:  # Novell LDAP Transaction unsolicited notification
-                    self.connection.last_error = 'transaction error'
-                    if log_enabled(ERROR):
-                        log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
-                    raise LDAPTransactionError(self.connection.last_error)
-
-                # if referral in response opens a new connection to resolve referrals if requested
-
-                if responses[-2]['result'] == RESULT_REFERRAL:
-                    if self.connection.usage:
-                        self.connection._usage.referrals_received += 1
-                    if self.connection.auto_referrals:
-                        ref_response, ref_result = self.do_operation_on_referral(self._outstanding[message_id], responses[-2]['referrals'])
-                        if ref_response is not None:
-                            responses = ref_response + [ref_result]
-                            responses.append(RESPONSE_COMPLETE)
-                        elif ref_result is not None:
-                            responses = [ref_result, RESPONSE_COMPLETE]
-
-                        self._referrals = []
-
-                if responses:
-                    result = responses[-2]
-                    response = responses[:-2]
-                    self.connection.result = None
-                    self.connection.response = None
-                    break
-
-            if timeout <= 0:
+            if not responses:
                 if log_enabled(ERROR):
                     log(ERROR, 'socket timeout, no response from server for <%s>', self.connection)
                 raise LDAPResponseTimeoutError('no response from server')
+
+            if responses == SESSION_TERMINATED_BY_SERVER:
+                try:  # try to close the session but don't raise any error if server has already closed the session
+                    self.close()
+                except (socket.error, LDAPExceptionError):
+                    pass
+                self.connection.last_error = 'session terminated by server'
+                if log_enabled(ERROR):
+                    log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
+                raise LDAPSessionTerminatedByServerError(self.connection.last_error)
+            elif responses == TRANSACTION_ERROR:  # Novell LDAP Transaction unsolicited notification
+                self.connection.last_error = 'transaction error'
+                if log_enabled(ERROR):
+                    log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
+                raise LDAPTransactionError(self.connection.last_error)
+
+            # if referral in response opens a new connection to resolve referrals if requested
+
+            if responses[-2]['result'] == RESULT_REFERRAL:
+                if self.connection.usage:
+                    self.connection._usage.referrals_received += 1
+                if self.connection.auto_referrals:
+                    ref_response, ref_result = self.do_operation_on_referral(self._outstanding[message_id], responses[-2]['referrals'])
+                    if ref_response is not None:
+                        responses = ref_response + [ref_result]
+                        responses.append(RESPONSE_COMPLETE)
+                    elif ref_result is not None:
+                        responses = [ref_result, RESPONSE_COMPLETE]
+
+                    self._referrals = []
+
+            if responses:
+                result = responses[-2]
+                response = responses[:-2]
+                self.connection.result = None
+                self.connection.response = None
 
             if self.connection.raise_exceptions and result and result['result'] not in DO_NOT_RAISE_EXCEPTIONS:
                 if log_enabled(PROTOCOL):
@@ -850,7 +843,7 @@ class BaseStrategy(object):
         # overridden on strategy class
         raise NotImplementedError
 
-    def _get_response(self, message_id):
+    def _get_response(self, message_id, timeout):
         # overridden in strategy class
         raise NotImplementedError
 

--- a/ldap3/strategy/ldifProducer.py
+++ b/ldap3/strategy/ldifProducer.py
@@ -123,7 +123,7 @@ class LdifProducerStrategy(BaseStrategy):
     def post_send_search(self, message_id):
         raise LDAPLDIFError('LDIF-CONTENT cannot be produced for Search operations')
 
-    def _get_response(self, message_id):
+    def _get_response(self, message_id, timeout):
         pass
 
     def accumulate_stream(self, fragment):

--- a/ldap3/strategy/reusable.py
+++ b/ldap3/strategy/reusable.py
@@ -68,7 +68,7 @@ class ReusableStrategy(BaseStrategy):
     def _start_listen(self):
         raise NotImplementedError
 
-    def _get_response(self, message_id):
+    def _get_response(self, message_id, timeout):
         raise NotImplementedError
 
     def get_stream(self):

--- a/ldap3/strategy/sync.py
+++ b/ldap3/strategy/sync.py
@@ -147,7 +147,7 @@ class SyncStrategy(BaseStrategy):
             log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
         raise LDAPSocketReceiveError(self.connection.last_error)
 
-    def _get_response(self, message_id):
+    def _get_response(self, message_id, timeout):
         """
         Performs the capture of LDAP response for SyncStrategy
         """


### PR DESCRIPTION
The current implementation of the ASYNC strategy checks the response every 0.05s
by default and it is a configurable item.
The mechanism is inefficient so introduce a event base checker.

Brief of the implementation:
1. Add a new dict to store the (message_id, event) pair
2. Add a new lock for the above dict
3. Create a Event object for every message_id
4. Set the event when receiving the entire response of the message
5. Wait on the event when accessing the response

Signed-off-by: Yang Qian <yang.qian@citrix.com>