### PR TITLE
Allow mixed case objectClass attribute name when mocking

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -224,7 +224,7 @@ class MockBaseStrategy(object):
                         return False
                     if attribute.lower() == 'objectclass' and self.connection.server.schema:  # builds the objectClass hierarchy only if schema is present
                         class_set = set()
-                        for object_class in attributes['objectClass']:
+                        for object_class in attributes[attribute]:
                             if self.connection.server.schema.object_classes and object_class not in self.connection.server.schema.object_classes:
                                 return False
                             # walkups the class hierarchy and buils a set of all classes in it


### PR DESCRIPTION
If you use mocking (Connection(..., client_strategy=MOCK_SYNC) and try to add an ldap entry and your attributes contain a lower case 'objectclass' attribute you get an error like the following:

'''
devel/pytest/lib/python3.7/site-packages/ldap3/core/connection.py:937: in add
    response = self.post_send_single_response(self.send('addRequest', request, controls))
devel/pytest/lib/python3.7/site-packages/ldap3/strategy/mockSync.py:112: in post_send_single_response
    result = add_response_to_dict(self.mock_add(request, controls))
devel/pytest/lib/python3.7/site-packages/ldap3/strategy/mockBase.py:379: in mock_add
    if self.add_entry(dn, attributes):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ldap3.strategy.mockSync.MockSyncStrategy object at 0x7fdc08f4f7b8>
dn = 'uid=example,ou=People,dc=example,dc=com'
attributes = {READACTED, ...}
validate = True

    def add_entry(self, dn, attributes, validate=True):
        with self.connection.server.dit_lock:
            escaped_dn = safe_dn(dn)
            if escaped_dn not in self.connection.server.dit:
                new_entry = CaseInsensitiveDict()
                for attribute in attributes:
                    if attribute in self.operational_attributes:  # no restore of operational attributes, should be computed at runtime
                        continue
                    if not isinstance(attributes[attribute], SEQUENCE_TYPES):  # entry attributes are always lists of bytes values
                        attributes[attribute] = [attributes[attribute]]
                    if self.connection.server.schema and self.connection.server.schema.attribute_types[attribute].single_value and len(attributes[attribute]) > 1:  # multiple values in single-valued attribute
                        return False
                    if attribute.lower() == 'objectclass' and self.connection.server.schema:  # builds the objectClass hierarchy only if schema is present
                        class_set = set()
>                       for object_class in attributes['objectClass']:
E                       KeyError: 'objectClass'

devel/pytest/lib/python3.7/site-packages/ldap3/strategy/mockBase.py:227: KeyError
'''