### PR TITLE
Fix searching by objectGUID in hex format

### DIFF
--- a/ldap3/protocol/formatters/validators.py
+++ b/ldap3/protocol/formatters/validators.py
@@ -401,9 +401,7 @@ def validate_uuid_le(input_value):
                     error = True
             elif '\\' in element:
                 try:
-                    uuid = UUID(bytes_le=ldap_escape_to_bytes(element)).bytes_le
-                    uuid = escape_bytes(uuid)
-                    valid_values.append(uuid)  # byte representation, value in little endian
+                    valid_values.append(UUID(bytes_le=ldap_escape_to_bytes(element)).bytes_le)  # byte representation, value in little endian
                     changed = True
                 except ValueError:
                     error = True


### PR DESCRIPTION
When searching by objectGUID in hex format, the `check_backslash`
function erroneously replaces all backslashes in the hex string
to `\5C`. Since for all other cases it is expected that the "valid value"
is a UUID little endian bytes string and not a hex string, this
commit changes it to that. This keeps `check_backslash` from doing
the wrong thing.

I tested this against Active Directory on Windows Server 2012 R2
with the following filter:
```python
'(&(objectClass=user)(objectGUID=\\87\\BB\\20\\A2\\08\\1B\\C4\\40\\94\\6F\\E2\\E6\\3F\\D7\\EF\\4B))'
```

The main motivation by this commit is to fix the MOCK_SYNC client strategy
for searches with the objectGUID filter.