### PR TITLE
Fixed referral attributes.

### DIFF
--- a/ldap3/utils/uri.py
+++ b/ldap3/utils/uri.py
@@ -101,7 +101,7 @@ def parse_uri(uri):
         else:
             uri_components['port'] = int(uri_components['port'])
 
-    uri_components['attributes'] = parts[1].split(',') if len(parts) > 1 else None
+    uri_components['attributes'] = parts[1].split(',') if len(parts) > 1 and parts[1] else None
     uri_components['scope'] = parts[2] if len(parts) > 2 else None
     if uri_components['scope'] == 'base':
         uri_components['scope'] = BASE


### PR DESCRIPTION
Referral attributes are not returned by the referral server:
If we use 'auto_referrals' and specify the attributes to be returned in the ldap search ldap3 will send the request to the primary server with correct 'AttributeSelection:uid'.
But if we follow referral ldap3 will send the request with missing attributes 'AttributeSelection:' (note uid is missing here).
This was caused by the incorrect uri parsing when attributes are not included into the uri:
```
>>> from ldap3.utils.uri import parse_uri
>>> uri = 'ldap://localhost/dc=04-dev-no-dockez??sub'
>>> parse_uri(uri)
{'filter': None, 'ssl': False, 'host': 'localhost', 'base': 'dc=04-dev-no-dockez', 'extensions': None, 'attributes': [''], 'scope': 'SUBTREE', 'port': None}
```

A list containing an empty string evaluates to True and primary server attributes are ignored. We should use "'attributes': None" instead so we will use the same attributes as on the primary LDAP server.