### PR TITLE
Add channel binding support for SASL + TLS

### DIFF
--- a/ldap3/utils/port_validators.py
+++ b/ldap3/utils/port_validators.py
@@ -17,7 +17,7 @@ def check_port_and_port_list(port, port_list):
     Return an error message indicating what is invalid if something isn't valid.
     """
     if port is not None and port_list is not None:
-        return 'Cannot specify both a source port and a source port list'
+        return'Cannot specify both a source port and a source port list'
     elif port is not None:
         if isinstance(port, int):
             if port not in range(0, 65535):

--- a/ldap3/utils/port_validators.py
+++ b/ldap3/utils/port_validators.py
@@ -17,7 +17,7 @@ def check_port_and_port_list(port, port_list):
     Return an error message indicating what is invalid if something isn't valid.
     """
     if port is not None and port_list is not None:
-        return'Cannot specify both a source port and a source port list'
+        return 'Cannot specify both a source port and a source port list'
     elif port is not None:
         if isinstance(port, int):
             if port not in range(0, 65535):


### PR DESCRIPTION
When building the connection base on SASL(Kerberos) + TLS to connect a Windows
ldap server (aka Domain Controller), we have to enforce ldap channel binding for
the connection otherwise the server will reject the connection.
See: https://support.microsoft.com/en-us/help/4520412/2020-ldap-channel-binding-and-ldap-signing-requirements-for-windows

This change also consider the useage of the SASL without TLS connection, so
won't calculate the channel binding token for that case.

Signed-off-by: Yang Qian <yang.qian@citrix.com>