### PR TITLE
Fix "invalid escape sequence \9" warning

### DIFF
--- a/ldap3/protocol/formatters/validators.py
+++ b/ldap3/protocol/formatters/validators.py
@@ -368,7 +368,7 @@ def validate_uuid(input_value):
 
 
 def validate_uuid_le(input_value):
-    """
+    r"""
     Active Directory stores objectGUID in uuid_le format, follows RFC4122 and MS-DTYP:
     "{07039e68-4373-264d-a0a7-07039e684373}": string representation big endian, converted to little endian (with or without brace curles)
     "689e030773434d26a7a007039e684373": packet representation, already in little endian


### PR DESCRIPTION
Mark validate_uuid_le's docstring as a raw string, otherwise "\9" et al. are interpreted as escape sequences - some invalid.

Fixes https://github.com/cannatag/ldap3/issues/612, which I believe couldn't be reproduced because the warning is only raised when the bytecode for this module is first generated. After that, the problem would seem to disappear.

I still see warning in v2.7, though.