### PR TITLE
Don't crash whole test suite with errors, just skip over missing LDAP server

### DIFF
--- a/test/config.py
+++ b/test/config.py
@@ -25,6 +25,7 @@ from os import environ, remove
 from os import path
 from random import SystemRandom
 from tempfile import gettempdir
+from unittest import SkipTest
 
 from ldap3 import SIMPLE, SYNC, ROUND_ROBIN, IP_V6_PREFERRED, IP_SYSTEM_DEFAULT, Server, Connection,\
     ServerPool, SASL, STRING_TYPES, get_config_parameter, set_config_parameter, \
@@ -380,7 +381,7 @@ elif location == 'W10GC9227-AD':
     test_logging_filename = path.join(gettempdir(), 'ldap3.log')
     test_valid_names = ['10.160.201.232']
 else:
-    raise Exception('testing location ' + location + ' is not valid')
+    raise SkipTest('testing location ' + location + ' is not valid')
 
 if test_logging:
     try:


### PR DESCRIPTION
Hi,

I am OpenSUSE maintainer of many Python packages and we try to run unit test in as many of our packages as possible. However, obviously we don’t have true LDAP server installed in the build system, the test suite crashes hard (because the function mistakenly uses `Exception()` instead of at least `AssertionError()`, which would make tests just fail).

Even better is just throw `unittest.SkipTest()` which makes failing tests be skipped in such build system.

I see on #115 that there are some mocking facilities inside of this package, is it possible somehow easily run the test suite against the mocked server?

Also, I am on the crusade of eliminating nose1 from our distribution. When I look at its repository on https://github.com/nose-devs/nose, the last release 1.3.7 was on 2 Jun 2015, and even the last commit on the master branch was on 4 Mar 2016. It seems to me that this project uses nose only for its test runner and it can be just replaced by for example pytest runner (or even ``python3 -munittest``).