### PR TITLE
Fix #854

### DIFF
--- a/ldap3/strategy/base.py
+++ b/ldap3/strategy/base.py
@@ -697,15 +697,15 @@ class BaseStrategy(object):
                                                 dereference_aliases=request['dereferenceAlias'],
                                                 attributes=[attr_type + ';range=' + str(int(high_range) + 1) + '-*'])
                 if self.connection.strategy.thread_safe:
-                    status, result, response, _ = result
+                    status, result, _response, _ = result
                 else:
                     status = result
                     result = self.connection.result
-                    response = self.connection.response
+                    _response = self.connection.response
 
                 if self.connection.strategy.sync:
                     if status:
-                        current_response = response[0]
+                        current_response = _response[0]
                     else:
                         done = True
                 else:


### PR DESCRIPTION
Potential fix for #854, seems like the response variable is getting overwritten every iteration, unlike previous behavior.

Not sure if this affects anything else in an unexpected way, but tested it on my project and it solves my issue and queries towards both AD and OpenLDAP seems to work as expected.

Commit which caused this issue: https://github.com/cannatag/ldap3/commit/72edc5eead0682e1bd787e053018c64079cd88e5#diff-b934c360851c1cfbfae4ea478912b14aL696-L703