### PR TITLE
Added more granular control over use of reverse dns with Kerberos.

### DIFF
--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -193,16 +193,26 @@ You can specify which Kerberos client principal should be used with the ``user``
 By default the library attempts to bind against the service principal for the domain you attempted to connect to.
 If your target LDAP service uses a round-robin DNS, it's likely that the hostname you connect to won't match. In this case,
 you can either specify a hostname explicitly as the first element of the ``sasl_credentials`` connection parameter,
-or pass ``True`` as the first element to do a reverse DNS lookup::
+or pass an appropriate value of the ``ReverseDnsSetting`` enum as the first element to do a reverse DNS lookup::
 
     # Override server hostname for authentication
     c = Connection(
         server, sasl_credentials=('ldap-3.example.com',),
         authentication=SASL, sasl_mechanism=KERBEROS)
 
-    # Perform a reverse DNS lookup to determine the hostname to authenticate against.
-    c = Connection(server, sasl_credentials=(True,), authentication=SASL, sasl_mechanism=KERBEROS)
-    
+    # Perform a reverse DNS lookup to determine the hostname to authenticate against regardless of server specification.
+    c = Connection(server, sasl_credentials=(ReverseDnsSetting.REQUIRE_RESOLVE_ALL_ADDRESSES,), authentication=SASL, sasl_mechanism=KERBEROS)
+
+    # Only perform a reverse DNS lookup to determine the hostname to authenticate against if the server's host is
+    # specified as an IP address
+    c = Connection(server, sasl_credentials=(ReverseDnsSetting.REQUIRE_RESOLVE_IP_ADDRESSES_ONLY,), authentication=SASL, sasl_mechanism=KERBEROS)
+
+    # Perform a reverse DNS lookup to determine the hostname to authenticate against, but if that lookup fails, proceed
+    # and attempt to use the server host as is.
+    # This is useful when working with serverpools where some servers are resolvable through reverse dns and need it,
+    # while other servers are not resolvable and do not need it.
+    c = Connection(server, sasl_credentials=(ReverseDnsSetting.OPTIONAL_RESOLVE_ALL_ADDRESSES,), authentication=SASL, sasl_mechanism=KERBEROS)
+
 
 .. note::
    `ldap3` does not currently support any SASL data security layers, only authentication.

--- a/ldap3/core/rdns.py
+++ b/ldap3/core/rdns.py
@@ -1,0 +1,63 @@
+""" Utilities and constants related to reverse dns lookup """
+
+# Created on 2020.09.16
+#
+# Author: Azaria Zornberg
+#
+# Copyright 2020 Giovanni Cannata
+# Copyright 2020 Azaria Zornberg
+#
+# This file is part of ldap3.
+#
+# ldap3 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ldap3 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with ldap3 in the COPYING and COPYING.LESSER files.
+# If not, see <http://www.gnu.org/licenses/>.
+
+import socket
+
+from enum import Enum
+
+
+class ReverseDnsSetting(Enum):
+    OFF = 0,
+    REQUIRE_RESOLVE_ALL_ADDRESSES = 1,
+    REQUIRE_RESOLVE_IP_ADDRESSES_ONLY = 2,
+    OPTIONAL_RESOLVE_ALL_ADDRESSES = 3,
+    OPTIONAL_RESOLVE_IP_ADDRESSES_ONLY = 4,
+
+
+def get_hostname_by_addr(addr, success_required=True):
+    """ Resolve the hostname for an ip address. If success is required, raise an exception if a hostname cannot
+    be resolved for the address.
+    Returns the hostname resolved for the address.
+    If success is not required, returns None for addresses that do not resolve to hostnames.
+    """
+    try:
+        return socket.gethostbyaddr(addr)[0]
+    except Exception as ex:
+        # if we need to succeed, just re-raise
+        if success_required:
+            raise
+    return None
+
+
+def is_ip_addr(addr):
+    """Returns True if an address is an ipv4 address or an ipv6 address based on format. False otherwise."""
+    for addr_type in [socket.AF_INET, socket.AF_INET6]:
+        try:
+            socket.inet_pton(addr_type, addr)
+            return True
+        except OSError:
+            pass
+
+    return False

--- a/test/testRdns.py
+++ b/test/testRdns.py
@@ -1,0 +1,89 @@
+""" Unit tests for utilities around reverse dns lookup """
+
+# Created on 2020.09.16
+#
+# Author: Azaria Zornberg
+#
+# Copyright 2020 Giovanni Cannata
+# Copyright 2020 Azaria Zornberg
+#
+# This file is part of ldap3.
+#
+# ldap3 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# ldap3 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with ldap3 in the COPYING and COPYING.LESSER files.
+# If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from ldap3.core.rdns import ReverseDnsSetting, get_hostname_by_addr, is_ip_addr
+
+
+class Test(unittest.TestCase):
+
+    def test_no_broken_backwards_compat_in_enum(self):
+        fail_msg = ('Changing the mapping of reverse dns enum types to numeric values will break backwards '
+                    'compatibility for existing clients on older versions of the ldap3 package. If new enum types '
+                    'are added or functionally changed, please use new values')
+        assert ReverseDnsSetting.OFF.value == (0,), fail_msg
+        assert ReverseDnsSetting.REQUIRE_RESOLVE_ALL_ADDRESSES.value == (1,), fail_msg
+        assert ReverseDnsSetting.REQUIRE_RESOLVE_IP_ADDRESSES_ONLY.value == (2,), fail_msg
+        assert ReverseDnsSetting.OPTIONAL_RESOLVE_ALL_ADDRESSES.value == (3,), fail_msg
+        assert ReverseDnsSetting.OPTIONAL_RESOLVE_IP_ADDRESSES_ONLY.value == (4,), fail_msg
+
+    def test_ipv4_ip_addr_checking(self):
+        valid = is_ip_addr('10.254.76.5')
+        assert valid is True, 'IPv4 addresses should be identified as ip addresses'
+
+    def test_ipv6_ip_addr_checking(self):
+        full_addr = '2001:0db8:0000:0000:0000:ff00:0042:8329'
+        zeros_reduced_addr = '2001:db8:0:0:0:ff00:42:8329'  # equivalent to above
+        consecutive_zeros_removed_addr = '2001:db8::ff00:42:8329'  # equivalent to above
+
+        for valid_ipv6_addr in [full_addr, zeros_reduced_addr, consecutive_zeros_removed_addr]:
+            valid = is_ip_addr(valid_ipv6_addr)
+            assert valid is True, ('IPv6 addresses should be identified as ip addresses regardless of format. {}'
+                                   .format(valid_ipv6_addr))
+
+    def test_hostname_ip_addr_checking(self):
+        valid = is_ip_addr('ldap.example.com')
+        assert valid is False, 'Hostnames should not be identified as ip addresses'
+
+    def test_success_required_option_for_lookup(self):
+        addr_that_fails_to_resolve = '10.254.76.09212'  # this address isn't valid so it'll fail to resolve
+        try:
+            host = get_hostname_by_addr(addr_that_fails_to_resolve)
+            assert False, ('An exception should be raised when invoking get_hostname_by_addr with default options '
+                           'for an address that cannot resolve.')
+        except AssertionError:
+            raise
+        except:
+            pass
+
+        try:
+            host = get_hostname_by_addr(addr_that_fails_to_resolve, success_required=True)
+            assert False, ('An exception should be raised when invoking get_hostname_by_addr with success_required '
+                           'set to True for an address that cannot resolve.')
+        except AssertionError:
+            raise
+        except:
+            pass
+
+        try:
+            host = get_hostname_by_addr(addr_that_fails_to_resolve, success_required=False)
+            assert host is None, ('An null host should be returned when invoking get_hostname_by_addr with '
+                                  'success_required set to False for an address that cannot resolve.')
+        except AssertionError:
+            raise
+        except Exception:
+            assert False, ('An exception should not be raised when invoking get_hostname_by_addr with success_required '
+                           'set to False for an address that cannot resolve.')


### PR DESCRIPTION
Previously the options for reverse dns with kerberos were "turn on (and effectively require)
reverse dns lookups for all servers in a connection's server pool", "do not use reverse dns
at all", and "I will manually specify the target name for kerberos".

These do not work well if you want to use a server pool that may contain servers that use
FQDNs already (but without reverse dns setup) or that mnay contains servers that use ip
addresses (which would need to be looked up via reverse dns). So this change adds options
beyond blanket required/off entirely.

It adds the enum options:
- Off
- Require reverse dns resolution for all servers
- Require reverse dns resolution only for servers using ip addresses
- Optionally resolve reverse dns for all servers
- Optionally resolve reverse dns only for servers using ip addresses

It also adds unit tests for the utilities added.

Signed-off-by: Azaria Zornberg <azaria.zornberg@purestorage.com>