### PR TITLE
update SASL EXTERNAL docs

### DIFF
--- a/docs/manual/source/ssltls.rst
+++ b/docs/manual/source/ssltls.rst
@@ -79,6 +79,14 @@ server trust the credential provided when establishing the secure channel::
      connection = Connection(server, auto_bind = True, version = 3, client_strategy = test_strategy, authentication = SASL,
                              sasl_mechanism = 'EXTERNAL', sasl_credentials = 'username')
 
+If the bind operation does not work with::
+
+     sasl_credentials = None
+
+you can try::
+
+     sasl_credentials = ''
+
 Digest-MD5
 ^^^^^^^^^^
 


### PR DESCRIPTION
Add hint about difference between values None and '' for sasl_credentials.

This cost me way too much time until I figured out the solution thanks to #114  
I think adding this Information to the docs might help others to get this working faster.