### PR TITLE
Implement LDAP signing (integrity checking) when using DIGEST-MD5 auth

### DIFF
--- a/docs/manual/source/bind.rst
+++ b/docs/manual/source/bind.rst
@@ -154,18 +154,28 @@ server trust the credential provided when establishing the secure channel::
 Digest-MD5
 ^^^^^^^^^^
 
-To use the DIGEST-MD5 mechanism you must pass a 4-value tuple as sasl_credentials: (realm, user, password, authz_id). You can pass None
-for 'realm' and 'authz_id' if not used. Quality of Protection is always 'auth'::
+To use the DIGEST-MD5 mechanism you must pass a 4-value or 5-value tuple as sasl_credentials: (realm, user, password, authz_id, enable_signing). You can pass None
+for 'realm', 'authz_id' and 'enable_signing' if not used::
 
     from ldap3 import Server, Connection, SASL, DIGEST_MD5
     server = Server(host = test_server, port = test_port)
     c = Connection(server, auto_bind = True, version = 3, client_strategy = test_strategy, authentication = SASL,
-                             sasl_mechanism = DIGEST_MD5, sasl_credentials = (None, 'username', 'password', None))
+                             sasl_mechanism = DIGEST_MD5, sasl_credentials = (None, 'username', 'password', None, 'sign'))
 
 Username is not required to be an LDAP entry, but it can be any identifier recognized by the server (i.e. email, principal, ...). If
 you pass None as 'realm' the default realm of the LDAP server will be used.
 
-**Again, remember that DIGEST-MD5 is deprecated and should not be used.**
+``enable_signing`` is an optional argument, which is only relevant for Digest-MD5 authentication. This argument enable or disable signing
+(Integrity protection) when performing LDAP queries.
+LDAP signing is a way to prevent replay attacks without encrypting the LDAP traffic. Microsoft publicly recommend to enforce LDAP signing when talking to
+an Active Directory server : https://support.microsoft.com/en-us/help/4520412/2020-ldap-channel-binding-and-ldap-signing-requirements-for-windows
+
+* When ``enable_signing`` is set to 'sign', LDAP requests are signed and signature of LDAP responses is verified.
+* When ``enable_signing`` is set to any other value or not set, LDAP requests are not signed.
+
+Also, DIGEST-MD5 authentication with encryption in addition to the integrity protection (``qop=auth-conf``) is not yet supported by ldap3.
+
+**Using DIGEST-MD5 without LDAP signing is considered deprecated and should not be used.**
 
 
 .. _sasl-kerberos:

--- a/docs/manual/source/ssltls.rst
+++ b/docs/manual/source/ssltls.rst
@@ -90,13 +90,23 @@ you can try::
 Digest-MD5
 ^^^^^^^^^^
 
-To use the DIGEST-MD5 you must pass a 4-value tuple as sasl_credentials: (realm, user, password, authz_id). You can pass None for 'realm' and 'authz_id' if not used. Quality of Protection is always 'auth'::
+To use the DIGEST-MD5 you must pass a 4-value or 5-value tuple as sasl_credentials: (realm, user, password, authz_id, enable_signing). You can pass None for 'realm', 'authz_id' and 'enable_signing' if not used::
 
      server = Server(host = test_server, port = test_port)
      connection = Connection(server, auto_bind = True, version = 3, client_strategy = test_strategy, authentication = SASL,
-                             sasl_mechanism = 'DIGEST-MD5', sasl_credentials = (None, 'username', 'password', None))
+                             sasl_mechanism = 'DIGEST-MD5', sasl_credentials = (None, 'username', 'password', None, 'sign'))
 
 Username is not required to be an LDAP entry, but it can be any identifier recognized by the server (i.e. email, principal, ...). If
 you pass None as 'realm' the default realm of the LDAP server will be used.
 
-**Again, remember that DIGEST-MD5 is deprecated and should not be used.**
+``enable_signing`` is an optional argument, which is only relevant for Digest-MD5 authentication. This argument enable or disable signing
+(Integrity protection) when performing LDAP queries.
+LDAP signing is a way to prevent replay attacks without encrypting the LDAP traffic. Microsoft publicly recommend to enforce LDAP signing when talking to
+an Active Directory server : https://support.microsoft.com/en-us/help/4520412/2020-ldap-channel-binding-and-ldap-signing-requirements-for-windows
+
+* When ``enable_signing`` is set to 'sign', LDAP requests are signed and signature of LDAP responses is verified.
+* When ``enable_signing`` is set to any other value or not set, LDAP requests are not signed.
+
+Also, DIGEST-MD5 authentication with encryption in addition to the integrity protection (``qop=auth-conf``) is not yet supported by ldap3.
+
+**Using DIGEST-MD5 without LDAP signing is considered deprecated and should not be used.**

--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -284,6 +284,9 @@ class Connection(object):
             self.use_referral_cache = use_referral_cache
             self.auto_escape = auto_escape
             self.auto_encode = auto_encode
+            self._digestMD5_Kic = None
+            self._digestMD5_Kis = None
+            self._digestMD5_secnum = 0
 
             port_err = check_port_and_port_list(source_port, source_port_list)
             if port_err:

--- a/ldap3/core/exceptions.py
+++ b/ldap3/core/exceptions.py
@@ -397,6 +397,9 @@ class LDAPInvalidTlsSpecificationError(LDAPExceptionError):
 class LDAPInvalidHashAlgorithmError(LDAPExceptionError, ValueError):
     pass
 
+class LDAPSignatureVerificationFailedError(LDAPExceptionError):
+    pass
+
 
 # connection exceptions
 class LDAPBindError(LDAPExceptionError):

--- a/ldap3/protocol/sasl/digestMd5.py
+++ b/ldap3/protocol/sasl/digestMd5.py
@@ -70,9 +70,9 @@ def md5_hmac(k, s):
 
 
 def sasl_digest_md5(connection, controls):
-    # sasl_credential must be a tuple made up of the following elements: (realm, user, password, authorization_id)
+    # sasl_credential must be a tuple made up of the following elements: (realm, user, password, authorization_id) or (realm, user, password, authorization_id, enable_signing)
     # if realm is None will be used the realm received from the server, if available
-    if not isinstance(connection.sasl_credentials, SEQUENCE_TYPES) or not len(connection.sasl_credentials) == 4:
+    if not isinstance(connection.sasl_credentials, SEQUENCE_TYPES) or not len(connection.sasl_credentials) in (4, 5):
         return None
 
     # step One of RFC2831
@@ -96,6 +96,9 @@ def sasl_digest_md5(connection, controls):
     cnonce = random_hex_string(16).encode(charset)
     uri = b'ldap/' + connection.server.host.encode(charset)
     qop = b'auth'
+    if len(connection.sasl_credentials) == 5 and connection.sasl_credentials[4] == 'sign' and not connection.server.ssl:
+        qop = b'auth-int'
+        connection._digestMD5_secnum = 0
 
     digest_response = b'username="' + user + b'",'
     digest_response += b'realm="' + realm + b'",'
@@ -111,6 +114,10 @@ def sasl_digest_md5(connection, controls):
     a0 = md5_h(b':'.join([user, realm, password]))
     a1 = b':'.join([a0, nonce, cnonce, authz_id]) if authz_id else b':'.join([a0, nonce, cnonce])
     a2 = b'AUTHENTICATE:' + uri + (b':00000000000000000000000000000000' if qop in [b'auth-int', b'auth-conf'] else b'')
+
+    if qop == b'auth-int':
+        connection._digestMD5_Kis = md5_h(md5_h(a1) + b"Digest session key to server-to-client signing key magic constant")
+        connection._digestMD5_Kic = md5_h(md5_h(a1) + b"Digest session key to client-to-server signing key magic constant")
 
     digest_response += b'response="' + md5_hex(md5_kd(md5_hex(md5_h(a1)), b':'.join([nonce, b'00000001', cnonce, qop, md5_hex(md5_h(a2))]))) + b'"'
 

--- a/ldap3/strategy/sync.py
+++ b/ldap3/strategy/sync.py
@@ -25,12 +25,13 @@
 
 import socket
 
-from .. import SEQUENCE_TYPES, get_config_parameter
-from ..core.exceptions import LDAPSocketReceiveError, communication_exception_factory, LDAPExceptionError, LDAPExtensionError, LDAPOperationResult
+from .. import SEQUENCE_TYPES, get_config_parameter, DIGEST_MD5
+from ..core.exceptions import LDAPSocketReceiveError, communication_exception_factory, LDAPExceptionError, LDAPExtensionError, LDAPOperationResult, LDAPSignatureVerificationFailedError
 from ..strategy.base import BaseStrategy, SESSION_TERMINATED_BY_SERVER, RESPONSE_COMPLETE, TRANSACTION_ERROR
 from ..protocol.rfc4511 import LDAPMessage
 from ..utils.log import log, log_enabled, ERROR, NETWORK, EXTENDED, format_ldap_message
 from ..utils.asn1 import decoder, decode_message_fast
+from ..protocol.sasl.digestMd5 import md5_h, md5_hmac
 
 LDAP_MESSAGE_TEMPLATE = LDAPMessage()
 
@@ -76,6 +77,11 @@ class SyncStrategy(BaseStrategy):
         data = b''
         get_more_data = True
         exc = None
+        sasl_total_bytes_recieved = 0
+        sasl_recieved_data = b'' # used to verify the signature
+        sasl_next_packet = b''
+        sasl_signature = b''
+        sasl_secNum = b'' # used to verify the signature
         while receiving:
             if get_more_data:
                 try:
@@ -90,7 +96,39 @@ class SyncStrategy(BaseStrategy):
                         log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
                     # raise communication_exception_factory(LDAPSocketReceiveError, exc)(self.connection.last_error)
                     raise communication_exception_factory(LDAPSocketReceiveError, type(e)(str(e)))(self.connection.last_error)
-                unprocessed += data
+
+                # If we are using DIGEST-MD5 and LDAP signing is set : verify & remove the signature from the message
+                if self.connection.sasl_mechanism == DIGEST_MD5 and self.connection._digestMD5_Kis and not self.connection.sasl_in_progress:
+                    data = sasl_next_packet + data
+
+                    if sasl_recieved_data == b'' or sasl_next_packet:
+                        # Remove the sizeOf(encoded_message + signature + 0x0001 + secNum) from data.
+                        sasl_buffer_length = int.from_bytes(data[0:4], "big")
+                        data = data[4:]
+                    sasl_next_packet = b''
+                    sasl_total_bytes_recieved += len(data)
+                    sasl_recieved_data += data
+
+                    if sasl_total_bytes_recieved >= sasl_buffer_length:
+                        # When the LDAP response is splitted accross multiple TCP packets, the SASL buffer length is equal to the MTU of each packet..Which is usually not equal to self.socket_size
+                        # This means that the end of one SASL packet/beginning of one other....could be located in the middle of data
+                        # We are using "sasl_recieved_data" instead of "data" & "unprocessed" for this reason
+
+                        # structure of messages when LDAP signing is enabled : sizeOf(encoded_message + signature + 0x0001 + secNum) + encoded_message + signature + 0x0001 + secNum
+                        sasl_signature = sasl_recieved_data[sasl_buffer_length - 16:sasl_buffer_length - 6]
+                        sasl_secNum = sasl_recieved_data[sasl_buffer_length - 4:sasl_buffer_length]
+                        sasl_next_packet = sasl_recieved_data[sasl_buffer_length:] # the last "data" variable may contain another sasl packet. We'll process it at the next iteration.
+                        sasl_recieved_data = sasl_recieved_data[:sasl_buffer_length - 16] # remove signature + 0x0001 + secNum + the next packet if any, from sasl_recieved_data
+
+                        Kis = self.connection._digestMD5_Kis
+                        calculated_signature = bytes.fromhex(md5_hmac(Kis, sasl_secNum + sasl_recieved_data)[0:20])
+                        if sasl_signature != calculated_signature:
+                            raise LDAPSignatureVerificationFailedError("Signature verification failed for the recieved LDAP message number " + str(int.from_bytes(sasl_secNum, 'big')) + ". Expected signature " + calculated_signature.hex() + " but got " + sasl_signature.hex() + ".")
+                        sasl_total_bytes_recieved = 0
+                        unprocessed += sasl_recieved_data
+                        sasl_recieved_data = b''
+                else:
+                    unprocessed += data
             if len(data) > 0:
                 length = BaseStrategy.compute_ldap_message_size(unprocessed)
                 if length == -1:  # too few data to decode message length


### PR DESCRIPTION
This PR implement optional LDAP signing (integrity protection) when using DIGEST-MD5 authentication.

LDAP signing is a way to prevent replay attacks & packets alteration attacks without encrypting the LDAP traffic. Microsoft publicly recommend to enforce signing when talking to an Active Directory server over a non-encrypted connection : https://support.microsoft.com/en-us/help/4520412/2020-ldap-channel-binding-and-ldap-signing-requirements-for-windows

My proposal : add an optional fifth argument to `sasl_credentials`: 

```
c = Connection(server, auto_bind = True, version = 3, client_strategy = test_strategy, authentication = SASL,
                             sasl_mechanism = DIGEST_MD5, sasl_credentials = (None, 'username', 'password', None, 'sign'))
```

- When this argument is set to the string `sign`, LDAP requests are signed and signature of LDAP responses is verified.
- When this argument is set to any other value or not set, LDAP requests are not signed.

This argument is ignored when not using DIGEST-MD5 authentication method. It is also ignored when using an LDAPS connection *(signing is not supported by most LDAP servers when using LDAPS, because the TLS connection is already providing replay protection so there is no need to sign)*

Fixes #889 