### PR TITLE
Update connection.rst to not have "s" undefined

### DIFF
--- a/docs/manual/source/connection.rst
+++ b/docs/manual/source/connection.rst
@@ -33,7 +33,7 @@ The following strategies are available:
 
       from ldap3 import Server, Connection, SAFE_SYNC
       server = Server('my_server')
-      conn = Connection(s, 'my_user', 'my_password', client_strategy=SAFE_SYNC, auto_bind=True)
+      conn = Connection(server, 'my_user', 'my_password', client_strategy=SAFE_SYNC, auto_bind=True)
       status, result, response, _ = conn.search('o=test', '(objectclass=*)')  # usually you don't need the original request (4th element of the return tuple)
 
    The SafeSync and SafeRestartable strategies can be used with the Abstract Layer, but the Abstract Layer currently is NOT thread safe.


### PR DESCRIPTION
In the old version

```
from ldap3 import Server, Connection, SAFE_SYNC
server = Server('my_server')
conn = Connection(s, 'my_user', 'my_password', client_strategy=SAFE_SYNC, auto_bind=True)
status, result, response, _ = conn.search('o=test', '(objectclass=*)')  # usually you don't need the original request (4th element of the return tuple)
```

the variable "s" would be undefined, I'm pretty sure that this variable was supposed to reference the "server" created before. Thus I changed s to server.