### PR TITLE
Updated tagMap and typeMap imports for pyasn1 0.5.0+

### DIFF
--- a/ldap3/utils/asn1.py
+++ b/ldap3/utils/asn1.py
@@ -47,7 +47,12 @@ if pyasn1_version == 'xxx0.2.3':
 
     tagMap[Boolean.tagSet] = BooleanCEREncoder()
 else:
-    from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
+    if pyasn1_version >= '0.5.0':
+        from pyasn1.codec.ber.encoder import AbstractItemEncoder
+        from pyasn1.codec.ber.encoder import TAG_MAP as tagMap
+        from pyasn1.codec.ber.encoder import TYPE_MAP as typeMap
+    else:
+        from pyasn1.codec.ber.encoder import tagMap, typeMap, AbstractItemEncoder
     from pyasn1.type.univ import Boolean
     from copy import deepcopy
 


### PR DESCRIPTION
pyasn1 likes making breaking changes. We already do a lot
of versioned imports/logic, so this is just one more.

In 0.5.0, tagMap and typeMap are renamed to TAG_MAP and
TYPE_MAP