### PR TITLE
Update to MockBaseStrategy to add entries_from_dict in lieu of entries_from_json

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -262,14 +262,18 @@ class MockBaseStrategy(object):
     def entries_from_json(self, json_entry_file):
         target = open(json_entry_file, 'r')
         definition = json.load(target, object_hook=json_hook)
-        if 'entries' not in definition:
+        self.entries_from_dict(definition)
+        target.close()
+
+    def entries_from_dict(self, dict_entries):
+        if 'entries' not in dict_entries:
             self.connection.last_error = 'invalid JSON definition, missing "entries" section'
             if log_enabled(ERROR):
                 log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
             raise LDAPDefinitionError(self.connection.last_error)
         if not self.connection.server.dit:
             self.connection.server.dit = CaseInsensitiveDict()
-        for entry in definition['entries']:
+        for entry in dict_entries['entries']:
             if 'raw' not in entry:
                 self.connection.last_error = 'invalid JSON definition, missing "raw" section'
                 if log_enabled(ERROR):
@@ -281,7 +285,6 @@ class MockBaseStrategy(object):
                     log(ERROR, '<%s> for <%s>', self.connection.last_error, self.connection)
                 raise LDAPDefinitionError(self.connection.last_error)
             self.add_entry(entry['dn'], entry['raw'], validate=False)
-        target.close()
 
     def mock_bind(self, request_message, controls):
         # BindRequest ::= [APPLICATION 0] SEQUENCE {


### PR DESCRIPTION
This is a quick, non-breaking change to the MockBaseStrategy used for mocking the ldap3 connection.  This change adds a new method `entries_from_dict` using the definition from `entries_from_json` (without the JSON file open and decode) that allows entries to be loaded from a dictionary object.  The method `entries_from_json` was then updated to use the new method (same code as before) but keeps the file open and decode using `json.load` as it did before.  The end result does not change any usage of `entries_from_json`, but adds the new option to load data from an opened and decoded file.

Looking at unit tests, I wasn't able to find any existing test that covers the `entries_from_json` method, so no tests were added or modified to cover the new code.  Any tests written in the future that cover `entries_from_json` would also cover the new `entires_from_dict`.  These methods are only used during testing, so unit tests may not be required.

Thank you for considering this small PR!!