### PR TITLE
Improve logging during connection restart

### DIFF
--- a/test/testRestartable.py
+++ b/test/testRestartable.py
@@ -27,9 +27,17 @@ import unittest
 
 from test.config import test_server, test_user, test_password, test_lazy_connection, test_get_info, test_server_mode, test_base, test_strategy, test_server_type
 from ldap3 import Server, Connection, ServerPool, RESTARTABLE, ROUND_ROBIN, BASE, MOCK_SYNC, MOCK_ASYNC
-
+from ldap3.utils.config import set_config_parameter
+import socket
 
 class Test(unittest.TestCase):
+
+    def setUp(self):
+        # these settings will speeed up the test execution 
+        set_config_parameter("RESTARTABLE_SLEEPTIME", 0.01)
+        set_config_parameter("RESTARTABLE_TRIES", 1)
+        set_config_parameter("POOLING_LOOP_TIMEOUT", 0)
+
     def test_restartable_invalid_server(self):
         if test_server_type != 'NONE' and test_strategy not in [MOCK_SYNC, MOCK_ASYNC]:
             if isinstance(test_server, (list, tuple)):
@@ -39,10 +47,9 @@ class Test(unittest.TestCase):
             search_results = []
             servers = [Server(host=host, port=636, use_ssl=True, get_info=test_get_info, mode=test_server_mode) for host in hosts]
             connection = Connection(ServerPool(servers, ROUND_ROBIN, active=True, exhaust=True), user=test_user, password=test_password, client_strategy=RESTARTABLE, lazy=test_lazy_connection, pool_name='pool1')
-
+                
             with connection as c:
                 c.search(search_base=test_base, search_filter='(' + test_base.split(',')[0] + ')', search_scope=BASE, attributes='*')
-
                 for resp in connection.response:
                     if resp['type'] == 'searchResEntry':
                         search_results.append(resp['dn'])
@@ -61,6 +68,30 @@ class Test(unittest.TestCase):
                 connection = Connection(server_pool, user=test_user, password=test_password, client_strategy=RESTARTABLE, lazy=False)
                 connection.open()
                 connection.bind()
+                connection.search(search_base=test_base, search_filter='(' + test_base.split(',')[0] + ')', search_scope=BASE)
+                if connection.response:
+                    for resp in connection.response:
+                        if resp['type'] == 'searchResEntry':
+                            search_results.append(resp['dn'])
+                connection.unbind()
+                self.assertEqual(len(search_results), 1)
+
+    def test_restartable_reconnect(self):
+        if test_server_type not in  ['NONE', 'AD']:
+            if test_strategy not in [MOCK_SYNC, MOCK_ASYNC]:
+                if isinstance(test_server, (list, tuple)):
+                    hosts = ['a.b.c.d'] + list(test_server)
+                else:
+                    hosts = ['a.b.c.d', test_server]
+                search_results = []
+                servers = [Server(host=host, port=389, use_ssl=False) for host in hosts]
+                server_pool = ServerPool(servers, ROUND_ROBIN, active=True, exhaust=True)
+                connection = Connection(server_pool, user=test_user, password=test_password, client_strategy=RESTARTABLE, lazy=False)
+                connection.open()
+                connection.bind()
+                #simulate broken connection
+                connection.socket.shutdown(socket.SHUT_RDWR)
+                #make sure we reconnect automatically
                 connection.search(search_base=test_base, search_filter='(' + test_base.split(',')[0] + ')', search_scope=BASE)
                 if connection.response:
                     for resp in connection.response:


### PR DESCRIPTION
When a restartable connection is left idle for a while, the server will close the socket. When the client
reuses the restartable connection, it reconnects automatically. However, it logs a lot of 
noise. This PR improves logging during reconnection.

original behavior (this gets logged even when the connection reconnects to the server):
DEBUG:ldap3:ERROR:<socket sending error[WinError 10058] A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call> for <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59900 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>

DEBUG:ldap3:ERROR:<socket sending error[WinError 10058] A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call> while restarting <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59900 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>

DEBUG:ldap3:ERROR:<restartable connection failed to send> for <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59900 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>

DEBUG:ldap3:ERROR:<LDAPMaximumRetriesError: restartable connection failed to send\Exception history:\    0 <class 'ldap3.core.exceptions.LDAPSocketSendError'>: socket sending error[WinError 10058] A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call\Maximum number of retries reached: 1> while restarting <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59900 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>


the same logs after the fix:
DEBUG:ldap3:ERROR:<socket sending error[WinError 10058] A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call> for <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59720 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>

DEBUG:ldap3:ERROR:<socket sending error[WinError 10058] A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call> while restarting <ldap://ipa.demo1.freeipa.org:389 - cleartext - user: uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org - not lazy - bound - open - <local: 10.10.10.103:59720 - remote: 52.57.162.88:389> - tls not started - listening - RestartableStrategy - internal decoder>