### PR TITLE
Don't use auto_bind=True in documentation

### DIFF
--- a/docs/manual/source/connection.rst
+++ b/docs/manual/source/connection.rst
@@ -31,9 +31,9 @@ The following strategies are available:
 
    * request: the original request of the operation::
 
-      from ldap3 import Server, Connection, SAFE_SYNC
+      from ldap3 import Server, Connection, SAFE_SYNC, AUTO_BIND_NO_TLS
       server = Server('my_server')
-      conn = Connection(server, 'my_user', 'my_password', client_strategy=SAFE_SYNC, auto_bind=True)
+      conn = Connection(server, 'my_user', 'my_password', client_strategy=SAFE_SYNC, auto_bind=AUTO_BIND_NO_TLS)
       status, result, response, _ = conn.search('o=test', '(objectclass=*)')  # usually you don't need the original request (4th element of the return tuple)
 
    The SafeSync and SafeRestartable strategies can be used with the Abstract Layer, but the Abstract Layer currently is NOT thread safe.


### PR DESCRIPTION
This patch switches from using the legacy option `auto_bind=True` to the equivalent new `auto_bind=AUTO_BIND_NO_TLS` in the documentation.