### PR TITLE
Import setuptools before distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ import os
 import glob
 import shutil
 from json import load
+from setuptools import setup
 from distutils.command.clean import clean
 from distutils import log
-from setuptools import setup
 
 version_dict = load(open('_version.json', 'r'))
 version = str(version_dict['version'])


### PR DESCRIPTION
setuptools 60 uses its own bunlded version of distutils, by default. It injects this into sys.modules, at import time. So we need to make sure that it is imported, before anything else imports distutils, to ensure everything is using the same distutils version.

This change in setuptools is to prepare for Python 3.12, which will drop distutils.