### PR TITLE
Set ciphers before validating the cert chain

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -185,18 +185,18 @@ class Tls(object):
                 elif self.validate != ssl.CERT_NONE:
                     ssl_context.load_default_certs(Purpose.SERVER_AUTH)
 
+            if self.ciphers:
+                try:
+                    ssl_context.set_ciphers(self.ciphers)
+                except ssl.SSLError:
+                    pass
+
             if self.certificate_file:
                 ssl_context.load_cert_chain(self.certificate_file, keyfile=self.private_key_file, password=self.private_key_password)
             ssl_context.check_hostname = False
             ssl_context.verify_mode = self.validate
             for option in self.ssl_options:
                 ssl_context.options |= option
-
-            if self.ciphers:
-                try:
-                    ssl_context.set_ciphers(self.ciphers)
-                except ssl.SSLError:
-                    pass
 
             if self.sni:
                 wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake, server_hostname=self.sni)


### PR DESCRIPTION
This patch fixes a bug with TLS cipher settings not being honored.

If the cipher defaults are sufficiently strict (like they are in python3.10 by default), certificate chains with a certificate signed using MD5, for example, will be rejected with this error:

    wrap socket error: [SSL: CA_MD_TOO_WEAK] ca md too weak (_ssl.c:3874)

The cipher settings as specified by the user should be set before loading the certificate chain.