### PR TITLE
bugfix in the ldap3.Tls initialization order

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -185,8 +185,6 @@ class Tls(object):
                 elif self.validate != ssl.CERT_NONE:
                     ssl_context.load_default_certs(Purpose.SERVER_AUTH)
 
-            if self.certificate_file:
-                ssl_context.load_cert_chain(self.certificate_file, keyfile=self.private_key_file, password=self.private_key_password)
             ssl_context.check_hostname = False
             ssl_context.verify_mode = self.validate
             for option in self.ssl_options:
@@ -197,6 +195,9 @@ class Tls(object):
                     ssl_context.set_ciphers(self.ciphers)
                 except ssl.SSLError:
                     pass
+            
+            if self.certificate_file:
+                ssl_context.load_cert_chain(self.certificate_file, keyfile=self.private_key_file, password=self.private_key_password)
 
             if self.sni:
                 wrapped_socket = ssl_context.wrap_socket(connection.socket, server_side=False, do_handshake_on_connect=do_handshake, server_hostname=self.sni)


### PR DESCRIPTION
On systems with newer openssl versions, openssl fails to load old certificates (e.g. Signature Algorithm: sha1WithRSAEncryption). This can be resolved by downgrading the security level with the ciphers parameter by setting e.g. `ALL:@SECLEVEL=0`.

This can be achieved by initializing the `ldap.Tls` class as the following: 
```
        tls = ldap3.Tls(
            local_private_key_file=key_file.name,
            local_certificate_file=cert_file.name,
            validate=ssl.CERT_NONE,
            ciphers='ALL:@SECLEVEL=0'
        )
```
However currently fails within the `ldap3.Tls` class because the `ssl_context.load_cert_chain` function is called before the `ssl_context.set_ciphers` function. 

This pull request swaps the order of operations to fix this bug.