### PR TITLE
Update tutorial_intro.rst usage of `auto_bind`

### DIFF
--- a/docs/manual/source/tutorial_intro.rst
+++ b/docs/manual/source/tutorial_intro.rst
@@ -158,9 +158,9 @@ Let's start accessing the server with an anonymous bind::
 
 or shorter::
 
-    >>> conn = Connection('ipa.demo1.freeipa.org', auto_bind=True)
+    >>> conn = Connection('ipa.demo1.freeipa.org', auto_bind=AUTO_BIND_NO_TLS)
 
-it could hardly be simpler than this. The ``auto_bind=True`` parameter forces the Bind operation to execute after creating the
+it could hardly be simpler than this. The ``auto_bind=AUTO_BIND_NO_TLS`` parameter forces the Bind operation to execute after creating the
 Connection object. You have now a full working anonymous session open and bound to the server with a *synchronous*
 communication strategy::
 


### PR DESCRIPTION
Update usage of `auto_bind` and replace legacy value of `True` with current hard coded `True`-Representation of `AUTO_BIND_NO_TLS`

See `connection.py` line 252ff

```python
            if auto_bind is False:  # compatibility with older version where auto_bind was a boolean
                self.auto_bind = AUTO_BIND_DEFAULT
            elif auto_bind is True:
                self.auto_bind = AUTO_BIND_NO_TLS
            else:
                self.auto_bind = auto_bind
```