### PR TITLE
fix: execute method instead of return it

### DIFF
--- a/ldap3/utils/dn.py
+++ b/ldap3/utils/dn.py
@@ -164,7 +164,7 @@ def _split_ava(ava, escape=False, strip=True):
             return attribute_type, attribute_value
         equal = ava.find('=', equal + 1)
 
-    return '', (ava.strip if strip else ava)  # if no equal found return only value
+    return '', (ava.strip() if strip else ava)  # if no equal found return only value
 
 
 def _validate_attribute_type(attribute_type):


### PR DESCRIPTION
Simple fix. I didn't manage to show a bug for this fix because I didn't manage to call `_split_ava` through "public" functions.

But it is clear that if it receives an ava starting with `=` and with `strip == True`, it will return something like `('', <built-in method strip of str object at 0xffffffffffff>)`, which is not what anyone wants.