### PR TITLE
fix using ServerPools with MOCK_* strategy

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -315,6 +315,9 @@ class Connection(object):
             if isinstance(server, ServerPool):
                 self.server_pool = server
                 self.server_pool.initialize(self)
+                if self.strategy_type in [MOCK_SYNC,MOCK_ASYNC]:
+                    for server in self.server_pool.servers:
+                        server.check_availability = lambda *_args, **_kwargs: True
                 self.server = self.server_pool.get_current_server(self)
             else:
                 self.server_pool = None


### PR DESCRIPTION
This fixes #1007

When using ServerPool's the Server to use is checked with check_availability. Since neither the Server nor the ServerPool know about the chosen connection strategy, we can just override the check_availability function when creating the Connection with a MOCK_* strategy.