### PR TITLE
Import MD4 from pycryptodomex package

### DIFF
--- a/ldap3/utils/ntlm.py
+++ b/ldap3/utils/ntlm.py
@@ -512,15 +512,8 @@ class NtlmClient(object):
             # The specified password is an LM:NTLM hash
             password_digest = binascii.unhexlify(passparts[1])
         else:
-            try:
-                password_digest = hashlib.new('MD4', self._password.encode('utf-16-le')).digest()
-            except ValueError as e:
-                try:
-                    from Crypto.Hash import MD4  # try with the Crypto library if present
-                    password_digest = MD4.new(self._password.encode('utf-16-le')).digest()
-                except ImportError:
-                    raise e  # raise original exception
-
+            from Cryptodome.Hash import MD4
+            password_digest = MD4.new(self._password.encode('utf-16-le')).digest()
         return hmac.new(password_digest, (self.user_name.upper() + self.user_domain).encode('utf-16-le'), digestmod=hashlib.md5).digest()
 
     def _kxkey(self, response_key_nt, nt_proof_str):


### PR DESCRIPTION
Now that the `pycryptodomex` package is listed as a requirement, we can just import `MD4` from the `Cryptodome` module to get rid of the annoying import problems.

They occurred when the system's OpenSSL does no longer enable MD4 and (and hence `hashlib` cannot use it) and the import from `Crypto` also fails because neither the legacy `pycrypto` package nor the `pycryptodome` package is installed. None of them was listed as a dependency. But now `pycryptodomex` is. :)

fixes #1051
fixes #1038