### PR TITLE
fix CBT computing when cert digest algo is not MD5, SHA1 or SHA256

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyasn1>=0.4.6
 pycryptodomex
 winkerberos
+cryptography


### PR DESCRIPTION
This PR fixes the CBT computing when cert digest is not MD5, SHA1 ou SHA256 (see [this comment](https://github.com/cannatag/ldap3/pull/1087#issuecomment-2217378883)). It also adds a "new" dependency: `cryptography`, however it seems that the project already uses it within the kerberos file but without installing it.

I choose `cryptography` because the project includes it already and because I havent found builtin python library that can parse a x509 certificate.

:sunflower: 