### PR TITLE
Correctly handle GSSAPI SASL negotiated max buffer size as per RFC4752

### DIFF
--- a/ldap3/core/connection.py
+++ b/ldap3/core/connection.py
@@ -297,6 +297,7 @@ class Connection(object):
             self._digest_md5_kcs_cipher = None
             self._digest_md5_sec_num = 0
             self.krb_ctx = None
+            self.krb_wrap_size_limit = None
 
             if session_security and not (self.authentication == NTLM or self.sasl_mechanism == GSSAPI):
                 self.last_error = '"session_security" option only available for NTLM and GSSAPI'


### PR DESCRIPTION
This PR adds code to correctly handle GSSAPI SASL negotiated max buffer size as per RFC4752.

As 0 was sent as the proposed max client buffer size (it should only be 0 if no security layers are configured), Samba would fail with error "gensec_gssapi_unwrap: WRAPPED data is larger than SASL negotiated maximum size".