### PR TITLE
Tls: add custom_ssl_context parameter

### DIFF
--- a/ldap3/core/tls.py
+++ b/ldap3/core/tls.py
@@ -87,7 +87,7 @@ class Tls(object):
                 if log_enabled(ERROR):
                     log(ERROR, 'cannot use custom_ssl_context, SSLContext not available')
                 raise LDAPSSLNotSupportedError('cannot use custom_ssl_context, SSLContext not available')
-            if not is instance(custom_ssl_context, ssl.SSLContext):
+            if not isinstance(custom_ssl_context, ssl.SSLContext):
                 if log_enabled(ERROR):
                     log(ERROR, 'custom_ssl_context must be an ssl.SSLContext object')
                 raise LDAPSSLNotSupportedError('custom_ssl_context must be an ssl.SSLContext object')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pyasn1>=0.4.6
 pycryptodomex
-winkerberos
+winkerberos; platform_system=='Windows'
+gssapi; platform_system!='Windows'


### PR DESCRIPTION
Add a custom_ssl_context parameter to `Tls()` to pass a custom `ssl.SSLContext` object for TLS connections. This allows configurations that currently are not supported in the code, such as more recent ssl options like [ssl.SSLContext.verify_flags](https://docs.python.org/3.11/library/ssl.html#ssl.SSLContext.verify_flags).

One use case is to enable [partial certificate chain verification](https://docs.python.org/3.11/library/ssl.html#ssl.VERIFY_X509_PARTIAL_CHAIN) for pinning certificates in situations where a root certificate is not available.