### PR TITLE
Require winkerberos only on Win32

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 pip
 pyasn1>=0.4.6
 pycryptodomex
-winkerberos
+winkerberos; sys_platform == "win32"
 setuptools
 sphinx
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyasn1>=0.4.6
 pycryptodomex
-winkerberos
+winkerberos; sys_platform == "win32"


### PR DESCRIPTION
Currently will not build on Linux because winkerberos is listed in requirements.txt and this package will not build on Linux. This PR adds a platform test to requirements.txt and requirements-dev.txt.