### PR TITLE
Add modify support for the RFC 4517 Postal Address format

### DIFF
--- a/ldap3/protocol/formatters/standard.py
+++ b/ldap3/protocol/formatters/standard.py
@@ -30,7 +30,7 @@ from .formatters import format_ad_timestamp, format_binary, format_boolean,\
 from .validators import validate_integer, validate_time, always_valid,\
     validate_generic_single_value, validate_boolean, validate_ad_timestamp, validate_sid,\
     validate_uuid_le, validate_uuid, validate_zero_and_minus_one_and_positive_int, validate_guid, validate_time_with_0_year,\
-    validate_ad_timedelta
+    validate_ad_timedelta, validate_postal
 
 # for each syntax can be specified a format function and a input validation function
 
@@ -82,7 +82,7 @@ standard_formatter = {
     '1.3.6.1.4.1.1466.115.121.1.38': (format_unicode, None),  # OID
     '1.3.6.1.4.1.1466.115.121.1.39': (format_unicode, None),  # Other mailbox
     '1.3.6.1.4.1.1466.115.121.1.40': (format_binary, None),  # Octet string
-    '1.3.6.1.4.1.1466.115.121.1.41': (format_postal, None),  # Postal address
+    '1.3.6.1.4.1.1466.115.121.1.41': (format_postal, validate_postal),  # Postal address
     '1.3.6.1.4.1.1466.115.121.1.42': (format_binary, None),  # Protocol Information [OBSOLETE]
     '1.3.6.1.4.1.1466.115.121.1.43': (format_binary, None),  # Presentation Address [OBSOLETE]
     '1.3.6.1.4.1.1466.115.121.1.44': (format_unicode, None),  # Printable string

--- a/ldap3/protocol/formatters/validators.py
+++ b/ldap3/protocol/formatters/validators.py
@@ -22,6 +22,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with ldap3 in the COPYING and COPYING.LESSER files.
 # If not, see <http://www.gnu.org/licenses/>.
+
+import re
+
 from binascii import a2b_hex, hexlify
 from datetime import datetime
 from calendar import timegm
@@ -494,6 +497,52 @@ def validate_sid(input_value):
 
     if changed:
         # valid_values = [check_backslash(value) for value in valid_values]
+        if sequence:
+            return valid_values
+        else:
+            return valid_values[0]
+    else:
+        return True
+
+
+def validate_postal(input_value):
+    """
+    RFC 4517 Postal Address
+
+    PostalAddress = line *( DOLLAR line )
+    line          = 1*line-char
+    line-char     = %x00-23
+                    / (%x5C "24")  ; escaped "$"
+                    / %x25-5B
+                    / (%x5C "5C")  ; escaped "\"
+                    / %x5D-7F
+                    / UTFMB
+    """
+    escape_pattern = re.compile(r'(\\)|(\$)|''(\n)')
+    escape_replace = (None, r'\5C', r'\24', '$')
+    def escape(match):
+        return escape_replace[match.lastindex]
+
+    if not isinstance(input_value, SEQUENCE_TYPES):
+        sequence = False
+        input_value = [input_value]
+    else:
+        sequence = True  # indicates if a sequence must be returned
+
+    valid_values = []
+    changed = False
+    for element in input_value:
+        if str is not bytes and isinstance(element, bytes):  # python3 try to converts bytes to string
+            element = to_unicode(element)
+        if isinstance(element, STRING_TYPES):
+            escaped = escape_pattern.sub(escape, element)
+            valid_values.append(escaped)
+            if escaped != element:
+                changed = True
+        else:
+            return False
+
+    if changed:
         if sequence:
             return valid_values
         else:

--- a/test/testValidators.py
+++ b/test/testValidators.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int
+from ldap3.protocol.formatters.validators import validate_integer, validate_boolean, validate_bytes, validate_generic_single_value, validate_time, validate_zero_and_minus_one_and_positive_int, validate_postal
 from ldap3.core.timezone import OffsetTzInfo
 
 class Test(unittest.TestCase):
@@ -202,3 +202,24 @@ class Test(unittest.TestCase):
         self.assertTrue(validated)
         validated = validate_zero_and_minus_one_and_positive_int('-2')
         self.assertFalse(validated)
+
+    def test_postal_validator_trivial(self):
+        self.assertTrue(validate_postal('abc'))
+        self.assertTrue(validate_postal(['abc', 'def', 'ghi']))
+        self.assertFalse(validate_postal(123))
+        self.assertFalse(validate_postal(['abc', 123, 'ghi']))
+
+    def test_postal_validator_escaped(self):
+        self.assertEqual(validate_postal('\n'), '$')
+        self.assertEqual(validate_postal('$'), r'\24')
+        self.assertEqual(validate_postal('\\'), r'\5C')
+        self.assertEqual(validate_postal(['\n', '$', '\\']), ['$', r'\24', r'\5C'])
+        self.assertEqual(validate_postal(['abc', '\n', 'def']), ['abc', '$', 'def'])
+
+    def test_postal_validator_rfc_examples(self):
+        self.assertEqual(
+            validate_postal('1234 Main St.\nAnytown, CA 12345\nUSA'),
+            r'1234 Main St.$Anytown, CA 12345$USA')
+        self.assertEqual(
+            validate_postal('$1,000,000 Sweepstakes\nPO Box 1000000\nAnytown, CA 12345\nUSA'),
+            r'\241,000,000 Sweepstakes$PO Box 1000000$Anytown, CA 12345$USA')


### PR DESCRIPTION
It's not possible to detect whether a string has already been RFC 4517 encoded, so if there are any users that currently do their own encoding before passing a postal address string to ldap3 then after this change they'll have to update their code to stop doing that (or else get the string doubly encoded). I believe that this is an acceptable breakage because the number of users that this would affect is most likely very small and they'd almost certainly appreciate no longer having to do their own encoding.