### PR TITLE
fix bug where trailing slashes are not stripped

### DIFF
--- a/ldap3/core/server.py
+++ b/ldap3/core/server.py
@@ -142,7 +142,7 @@ class Server(object):
             raise LDAPInvalidServerError()
 
         if not self.ipc:
-            self.host.rstrip('/')
+            self.host = self.host.rstrip('/')
             if not use_ssl and not port:
                 port = 389
             elif use_ssl and not port:


### PR DESCRIPTION
example:
```py
import ldap3
srv = ldap3.Server(sys.argv[1], port=636, connect_timeout=1)
conn = ldap3.Connection(srv, auto_bind=True)
conn.unbind()
print("success!")
```

```console
$ python /tmp/test-ldap.py ldaps://myldapserver/
Traceback (most recent call last):
  File "/tmp/test-ldap-hang.py", line 3, in <module>
    conn = ldap3.Connection(srv, auto_bind=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/ldap3/core/connection.py", line 363, in __init__
    self._do_auto_bind()
  File "/usr/lib/python3/dist-packages/ldap3/core/connection.py", line 387, in _do_auto_bind
    self.open(read_server_info=False)
  File "/usr/lib/python3/dist-packages/ldap3/strategy/sync.py", line 57, in open
    BaseStrategy.open(self, reset_usage, read_server_info)
  File "/usr/lib/python3/dist-packages/ldap3/strategy/base.py", line 154, in open
    raise LDAPSocketOpenError('invalid server address')
ldap3.core.exceptions.LDAPSocketOpenError: invalid server address

$ python /tmp/test-ldap.py ldaps://myldapserver
success!
```

I went to add this line and it looks like somebody already tried to add it but made a syntax error. Git blame on this line is no use, it leads back to [the mother of all commits](https://github.com/cannatag/ldap3/commit/71fe2c57dc1f32ca1666bc550f7e6dd7e6e40e93).