### PR TITLE
Allow empty base for mocks

### DIFF
--- a/ldap3/strategy/mockBase.py
+++ b/ldap3/strategy/mockBase.py
@@ -664,7 +664,10 @@ class MockBaseStrategy(object):
 
     def _execute_search(self, request):
         responses = []
-        base = safe_dn(request['base'])
+        if request['base']:
+            base = safe_dn(request['base'])
+        else:
+            base = request['base']
         scope = request['scope']
         attributes = request['attributes']
         if '+' in attributes:  # operational attributes requested


### PR DESCRIPTION
Started to do some testing recently with the mock interface and it works great!

Found out though that you need to specify a base when using mocks but not when using "real" code.

Connection.search seems to handle it similar to how attached patch does it:
https://github.com/cannatag/ldap3/blob/2b4d94e71dd26d3aeb937a350777c8be88e5c7ca/ldap3/core/connection.py#L829-L830

But I wonder if adding it here:
https://github.com/cannatag/ldap3/blob/2b4d94e71dd26d3aeb937a350777c8be88e5c7ca/ldap3/utils/dn.py#L330-L335
might be more generic? Like:
```python
    if dn == "":
        return dn
```

What do you think?