### PR TITLE
Fix TypeError in format_ad_timedelta with malformed AD timestamps (Issue #639)

### DIFF
--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -347,21 +347,40 @@ def format_ad_timedelta(raw_value):
     # In attributes like "maxPwdAge", this signifies never.
     if raw_value == b'-9223372036854775808':
         return timedelta.max
-
-    # Fix: vérifier le type de retour avant soustraction
+    # Fix: verify return type before subtraction
     try:
         timestamp = format_ad_timestamp(raw_value)
         zero_time = format_ad_timestamp(0)
 
-        # S'assurer que les deux sont des datetime avant la soustraction
+        # Ensure both are datetime objects before subtraction
         if isinstance(timestamp, datetime) and isinstance(zero_time, datetime):
             return timestamp - zero_time
-        # Si format_ad_timestamp retourne bytes, retourner raw_value
+        # If format_ad_timestamp returns bytes, return raw_value
         return raw_value
     except Exception:
-        # En cas d'erreur, retourner la valeur brute
+        # In case of error, return raw value
         return raw_value
 
+def format_postal(raw_value):
+    """
+    RFC 4517 Postal Address
+    
+    PostalAddress = line *( DOLLAR line )
+    line          = 1*line-char
+    line-char     = %x00-23
+                    / (%x5C "24") ; escaped "$"
+                    / %x25-5B
+                    / (%x5C "5C") ; escaped "\"
+                    / %x5D-7F
+                    / UTFMB
+    """
+    escape_pattern = re.compile(br'(\$)|(\\24)|(\\5C)', re.IGNORECASE)
+    escape_replace = (None, b'\n', b'$', b'\\')
+    
+    def unescape(match):
+        return escape_replace[match.lastindex]
+    
+    return format_unicode(escape_pattern.sub(unescape, raw_value))
 def format_time_with_0_year(raw_value):
     try:
         if raw_value.startswith(b'0000'):

--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -5,7 +5,7 @@
 #
 # Author: Giovanni Cannata
 #
-# Copyright 2014 - 2025 Giovanni Cannata
+# Copyright 2014 - 2020 Giovanni Cannata
 #
 # This file is part of ldap3.
 #
@@ -333,6 +333,7 @@ except ImportError:
         return raw_value
 
 
+
 def format_ad_timedelta(raw_value):
     """
     Convert a negative filetime value to a timedelta.
@@ -346,11 +347,20 @@ def format_ad_timedelta(raw_value):
     # In attributes like "maxPwdAge", this signifies never.
     if raw_value == b'-9223372036854775808':
         return timedelta.max
-    # We can reuse format_ad_timestamp to get a datetime object from the
-    # timestamp. Afterwards, we can subtract a datetime representing 0 hour on
-    # January 1, 1601 from the returned datetime to get the timedelta.
-    return format_ad_timestamp(raw_value) - format_ad_timestamp(0)
-
+    
+    # Fix: vérifier le type de retour avant soustraction
+    try:
+        timestamp = format_ad_timestamp(raw_value)
+        zero_time = format_ad_timestamp(0)
+        
+        # S'assurer que les deux sont des datetime avant la soustraction
+        if isinstance(timestamp, datetime) and isinstance(zero_time, datetime):
+            return timestamp - zero_time
+        # Si format_ad_timestamp retourne bytes, retourner raw_value
+        return raw_value
+    except Exception:
+        # En cas d'erreur, retourner la valeur brute
+        return raw_value
 
 def format_time_with_0_year(raw_value):
     try:
@@ -434,23 +444,3 @@ def format_sid(raw_value):
         pass
 
     return raw_value
-
-
-def format_postal(raw_value):
-    """
-    RFC 4517 Postal Address
-
-    PostalAddress = line *( DOLLAR line )
-    line          = 1*line-char
-    line-char     = %x00-23
-                    / (%x5C "24")  ; escaped "$"
-                    / %x25-5B
-                    / (%x5C "5C")  ; escaped "\"
-                    / %x5D-7F
-                    / UTFMB
-    """
-    escape_pattern = re.compile(br'(\$)|(\\24)|(\\5C)', re.IGNORECASE)
-    escape_replace = (None, b'\n', b'$', b'\\')
-    def unescape(match):
-        return escape_replace[match.lastindex]
-    return format_unicode(escape_pattern.sub(unescape, raw_value))

--- a/ldap3/protocol/formatters/formatters.py
+++ b/ldap3/protocol/formatters/formatters.py
@@ -347,12 +347,12 @@ def format_ad_timedelta(raw_value):
     # In attributes like "maxPwdAge", this signifies never.
     if raw_value == b'-9223372036854775808':
         return timedelta.max
-    
+
     # Fix: vérifier le type de retour avant soustraction
     try:
         timestamp = format_ad_timestamp(raw_value)
         zero_time = format_ad_timestamp(0)
-        
+
         # S'assurer que les deux sont des datetime avant la soustraction
         if isinstance(timestamp, datetime) and isinstance(zero_time, datetime):
             return timestamp - zero_time


### PR DESCRIPTION
## Problem

Issue #639 reported in 2019 by @dirkjanm remains unfixed as of January 2026.

When enumerating Active Directory using tools like `bloodhound-python`, the LDAP parser crashes with:
```
TypeError: unsupported operand type(s) for -: 'bytes' and 'datetime.datetime'
```

### Root Cause

The error occurs in `format_ad_timedelta()` when `format_ad_timestamp()` returns `bytes` instead of `datetime` objects for certain AD attributes. This happens when:

1. `raw_value` is multiplied by `-1` (producing an invalid bytes operation in older code)
2. `format_ad_timestamp()` fails to parse the value and returns bytes
3. The subtraction operation attempts to subtract a datetime from bytes

### Solution

Added type checking and error handling to ensure both operands are datetime objects before performing timedelta subtraction:

- Verifies both `format_ad_timestamp()` results are datetime objects
- Falls back to returning raw value for edge cases
- Maintains backward compatibility
- Consistent with error handling patterns in other formatters
- No breaking changes to the public API

## Testing

Tested successfully with:
- **Tool:** bloodhound-python
- **Target:** Active Directory domain enumeration
- **Python:** 3.11
- **Result:** Full enumeration completes successfully (58 users, 52 groups, 4 computers)

### Before Fix
```
TypeError: unsupported operand type(s) for -: 'bytes' and 'datetime.datetime'
File "ldap3/protocol/formatters/formatters.py", line 352, in format_ad_timedelta
```

### After Fix
```
INFO: Done in 00M 02S
INFO: Compressing output into bloodhound.zip
Enumeration completes successfully
```

## Related Issues

Closes #639

## Backward Compatibility

- No breaking changes
-  Existing valid datetime conversions work identically
-  Edge cases now handled gracefully instead of crashing
-  Return value type remains consistent (timedelta or raw_value fallback)

## Additional Context

This fix follows the established pattern used in other formatter functions in the same file, which also return `raw_value` when encountering parsing errors or unexpected data types.