### PR TITLE
docs/mocking: mention how to create a user to bind against

### DIFF
--- a/docs/manual/source/mocking.rst
+++ b/docs/manual/source/mocking.rst
@@ -39,6 +39,13 @@ Then you can use the mock connection as a normal connection to an LDAP server.
     (either single or multi-valued). The password must be stored as cleartext. You cannot use the ``auto_bind`` parameter because the DIT is
     populated after the creation of the Connection object.
 
+.. hint::
+
+    If your json does not contain users, you can create one on the fly before calling ``bind()``::
+
+       connection.strategy.add_entry('cn=my_user,ou=test,o=lab', {'userPassword': 'my_password'})
+
+
 MockBaseStrategy supports the Bind, Unbind, Add, Modify, ModifyDn, Compare, Delete and Search operations (except for the
 extensible match). Abandon and Extended are not supported.
 


### PR DESCRIPTION
This adds an explicit hint regarding how to create an entry on the fly so `bind()` can work.

It is documented right above the hint, but I ended up not realizing that it was as easy as adding an entry. It has also come up in the past (e.g. #1094), so I figured it wouldn't hurt to make it a little more obvious.